### PR TITLE
[HOPSWORKS-895] bugfix get_project_featurestore edge case

### DIFF
--- a/src/main/java/io/hops/util/featurestore/FeaturestoreHelper.java
+++ b/src/main/java/io/hops/util/featurestore/FeaturestoreHelper.java
@@ -176,7 +176,7 @@ public class FeaturestoreHelper {
    */
   public static String getProjectFeaturestore() {
     String projectName = Hops.getProjectName();
-    return projectName + "_featurestore";
+    return projectName.toLowerCase() + "_featurestore";
   }
 
   /**


### PR DESCRIPTION
- get_project_featurestore can return wrong result if project name contains upper-case letters