### PR TITLE
[HOPSWORKS-986] Refactor Featurestore Java API

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,45 +96,25 @@ import scala.collection.JavaConversions._
 import collection.JavaConverters._
 
 val features = List("team_budget", "average_attendance", "average_player_age")
-Hops.getFeatures(spark, features, Hops.getProjectFeaturestore).show(5)
+val featuresDf = Hops.getFeatures(features).read()
 ```
 
 #### SQL Query to the Feature Store
 
 ``` scala
 import io.hops.util.Hops
-Hops.queryFeaturestorequeryFea (spark,
+Hops.queryFeaturestore(
     "SELECT team_budget, score " +
     "FROM teams_features_1 JOIN games_features_1 ON " +
-    "games_features_1.home_team_id = teams_features_1.team_id", Hops.getProjectFeaturestore).show()
+    "games_features_1.home_team_id = teams_features_1.team_id").read().show(5)
 ```
 
 #### Write to the Feature Store
 
 ``` scala
 import io.hops.util.Hops
-import scala.collection.JavaConversions._
-import collection.JavaConverters._
 
-val jobId = null
-val dependencies = List[String]().asJava
-val primaryKey = null
-val descriptiveStats = false
-val featureCorr = false
-val featureHistograms = false
-val clusterAnalysis = false
-val statColumns = List[String]().asJava
-val numBins = null
-val corrMethod = null
-val numClusters = null
-val description = "a spanish version of teams_features"
-
-Hops.createFeaturegroup(
-    spark, teamsFeaturesDf2, "teams_features_spanish", Hops.getProjectFeaturestore,
-    1, description, jobId,
-    dependencies, primaryKey, descriptiveStats, featureCorr,
-      featureHistograms, clusterAnalysis, statColumns, numBins,
-      corrMethod, numClusters)
+Hops.createFeaturegroup("teams_features_spanish").setDataframe(teamsFeaturesDf2).write()      
 ```
 
 A complete example of the Scala/Java API for the Feature Store is available [here](https://github.com/Limmen/hops-examples/blob/HOPSWORKS-721/notebooks/featurestore/FeaturestoreTourScala.ipynb).

--- a/src/main/java/io/hops/util/FeaturestoreRestClient.java
+++ b/src/main/java/io/hops/util/FeaturestoreRestClient.java
@@ -1,0 +1,344 @@
+package io.hops.util;
+
+import io.hops.util.exceptions.FeaturegroupCreationError;
+import io.hops.util.exceptions.FeaturegroupDeletionError;
+import io.hops.util.exceptions.FeaturegroupUpdateStatsError;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.exceptions.FeaturestoresNotFound;
+import io.hops.util.exceptions.HTTPSClientInitializationException;
+import io.hops.util.exceptions.JWTNotFoundException;
+import io.hops.util.exceptions.TrainingDatasetCreationError;
+import io.hops.util.featurestore.FeaturegroupsAndTrainingDatasetsDTO;
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.feature.FeatureDTO;
+import io.hops.util.featurestore.stats.StatisticsDTO;
+import org.json.JSONObject;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.Response;
+import javax.xml.bind.JAXBException;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Exposes featurestore RPC/Rest API
+ */
+public class FeaturestoreRestClient {
+  
+  private FeaturestoreRestClient(){}
+  
+  private static final Logger LOG = Logger.getLogger(FeaturestoreRestClient.class.getName());
+  
+  /**
+   * Makes a REST call to Hopsworks to get metadata about a featurestore, this metadata is then used by
+   * hops-util to infer how to JOIN featuregroups together etc.
+   *
+   * @param featurestore the featurestore to query metadata about
+   * @return a list of featuregroups metadata
+   * @throws FeaturestoreNotFound FeaturestoresNotFound
+   * @throws JAXBException JAXBException
+   */
+  public static FeaturegroupsAndTrainingDatasetsDTO getFeaturestoreMetadataRest(String featurestore)
+    throws FeaturestoreNotFound, JAXBException {
+    LOG.log(Level.FINE, "Getting featuregroups for featurestore " + featurestore);
+    
+    Response response;
+    try {
+      response =
+        Hops.clientWrapper(
+          "/project/" + Hops.getProjectId() + "/" + Constants.HOPSWORKS_REST_FEATURESTORES_RESOURCE + "/" +
+            Constants.HOPSWORKS_REST_FEATURESTORE_RESOURCE + "/" + featurestore,
+          HttpMethod.GET);
+    } catch (HTTPSClientInitializationException | JWTNotFoundException e) {
+      throw new FeaturestoreNotFound(e.getMessage());
+    }
+    LOG.log(Level.INFO, "******* response.getStatusInfo():" + response.getStatusInfo());
+    if (response.getStatusInfo().getStatusCode() != Response.Status.OK.getStatusCode()) {
+      throw new FeaturestoreNotFound("Could not fetch featuregroups for featurestore:" + featurestore);
+    }
+    final String responseEntity = response.readEntity(String.class);
+    
+    JSONObject featurestoreMetadata = new JSONObject(responseEntity);
+    return FeaturestoreHelper.parseFeaturestoreMetadataJson(featurestoreMetadata);
+  }
+  
+  /**
+   * Makes a REST call to Hopsworks for deleting
+   * the contents of the featuregroup but keeps the featuregroup metadata
+   *
+   * @param featurestore        the featurestore where the featuregroup resides
+   * @param featuregroup        the featuregroup to drop the contents of
+   * @param featuregroupVersion the version of the featurergroup
+   * @throws JWTNotFoundException JWTNotFoundException
+   * @throws FeaturegroupDeletionError FeaturegroupDeletionError
+   */
+  public static void deleteTableContentsRest(
+    String featurestore, String featuregroup, int featuregroupVersion)
+    throws JWTNotFoundException, FeaturegroupDeletionError {
+    LOG.log(Level.FINE, "Deleting table contents of featuregroup " + featuregroup +
+      "version: " + featuregroupVersion + " in featurestore: " + featurestore);
+    
+    JSONObject json = new JSONObject();
+    json.append(Constants.JSON_FEATURESTORE_NAME, featurestore);
+    json.append(Constants.JSON_FEATUREGROUP_NAME, featuregroup);
+    json.append(Constants.JSON_FEATUREGROUP_VERSION, featuregroupVersion);
+    try {
+      Response response = Hops.clientWrapper(json,
+        "/project/" + Hops.getProjectId() + "/" + Constants.HOPSWORKS_REST_FEATURESTORES_RESOURCE + "/" +
+          Constants.HOPSWORKS_REST_CLEAR_FEATUREGROUP_RESOURCE,
+        HttpMethod.POST);
+      LOG.log(Level.INFO, "******* response.getStatusInfo():" + response.getStatusInfo());
+      if (response.getStatusInfo().getStatusCode() != Response.Status.OK.getStatusCode()) {
+        throw new FeaturegroupDeletionError("Could not clear the contents of featuregroup:" + featuregroup);
+      }
+    } catch (HTTPSClientInitializationException e) {
+      throw new FeaturegroupDeletionError(e.getMessage());
+    }
+  }
+  
+  /**
+   * Makes a REST call to Hopsworks for creating a new featuregroup from a spark dataframe.
+   *
+   * @param featurestore        the featurestore where the group will be created
+   * @param featuregroup        the name of the featuregroup
+   * @param featuregroupVersion the version of the featuregroup
+   * @param description         the description of the featuregroup
+   * @param jobName               the name of the job to compute the featuregroup
+   * @param dependencies        a list of dependencies (datasets that this featuregroup depends on)
+   * @param featuresSchema      schema of features for the featuregroup
+   * @param statisticsDTO       statistics about the featuregroup
+   * @throws JWTNotFoundException JWTNotFoundException
+   * @throws JAXBException JAXBException
+   * @throws FeaturegroupCreationError FeaturegroupCreationError
+   */
+  public static void createFeaturegroupRest(
+    String featurestore, String featuregroup, int featuregroupVersion, String description,
+    String jobName, List<String> dependencies, List<FeatureDTO> featuresSchema,
+    StatisticsDTO statisticsDTO)
+    throws JWTNotFoundException, JAXBException, FeaturegroupCreationError {
+    LOG.log(Level.FINE, "Creating featuregroup " + featuregroup + " in featurestore: " + featurestore);
+    JSONObject json = new JSONObject();
+    json.put(Constants.JSON_FEATURESTORE_NAME, featurestore);
+    json.put(Constants.JSON_FEATUREGROUP_NAME, featuregroup);
+    json.put(Constants.JSON_FEATUREGROUP_VERSION, featuregroupVersion);
+    json.put(Constants.JSON_FEATUREGROUP_DESCRIPTION, description);
+    json.put(Constants.JSON_FEATUREGROUP_JOBNAME, jobName);
+    json.put(Constants.JSON_FEATUREGROUP_DEPENDENCIES, dependencies);
+    json.put(Constants.JSON_FEATUREGROUP_FEATURES,
+      FeaturestoreHelper.convertFeatureDTOsToJsonObjects(featuresSchema));
+    json.put(Constants.JSON_FEATUREGROUP_FEATURE_CORRELATION,
+      FeaturestoreHelper.convertFeatureCorrelationMatrixDTOToJsonObject(
+        statisticsDTO.getFeatureCorrelationMatrixDTO()));
+    json.put(Constants.JSON_FEATUREGROUP_DESC_STATS,
+      FeaturestoreHelper.convertDescriptiveStatsDTOToJsonObject(statisticsDTO.getDescriptiveStatsDTO()));
+    json.put(Constants.JSON_FEATUREGROUP_FEATURES_HISTOGRAM, FeaturestoreHelper
+      .convertFeatureDistributionsDTOToJsonObject(statisticsDTO.getFeatureDistributionsDTO()));
+    json.put(Constants.JSON_FEATUREGROUP_CLUSTER_ANALYSIS, FeaturestoreHelper
+      .convertClusterAnalysisDTOToJsonObject(statisticsDTO.getClusterAnalysisDTO()));
+    json.put(Constants.JSON_FEATUREGROUP_UPDATE_METADATA, false);
+    json.put(Constants.JSON_FEATUREGROUP_UPDATE_STATS, false);
+    Response response;
+    try {
+      response = Hops.clientWrapper(json,
+        "/project/" + Hops.getProjectId() + "/" + Constants.HOPSWORKS_REST_FEATURESTORES_RESOURCE + "/" +
+          Constants.HOPSWORKS_REST_CREATE_FEATUREGROUP_RESOURCE,
+        HttpMethod.POST);
+    } catch (HTTPSClientInitializationException e) {
+      throw new FeaturegroupCreationError(e.getMessage());
+    }
+    LOG.log(Level.INFO, "******* response.getStatusInfo():" + response.getStatusInfo());
+    if (response.getStatusInfo().getStatusCode() != Response.Status.CREATED.getStatusCode()) {
+      HopsworksErrorResponseDTO hopsworksErrorResponseDTO = Hops.parseHopsworksErrorResponse(response);
+      throw new FeaturegroupCreationError("Could not create featuregroup:" + featuregroup +
+        " , error code: " + hopsworksErrorResponseDTO.getErrorCode() + " error message: "
+        + hopsworksErrorResponseDTO.getErrorMsg() + ", user message: " + hopsworksErrorResponseDTO.getUserMsg());
+    }
+  }
+  
+  /**
+   * Makes a REST call to Hopsworks for creating a new training dataset from a spark dataframe
+   *
+   * @param featurestore           the featurestore where the group will be created
+   * @param trainingDataset
+   * @param trainingDatasetVersion the version of the featuregroup
+   * @param description            the description of the featuregroup
+   * @param jobName                  the name of the job to compute the featuregroup
+   * @param dependencies           a list of dependencies (datasets that this featuregroup depends on)
+   * @param featuresSchema         schema of features for the featuregroup
+   * @param statisticsDTO          statistics about the featuregroup
+   * @param dataFormat             format of the dataset (e.g tfrecords)
+   * @return the JSON response
+   * @throws JWTNotFoundException JWTNotFoundException
+   * @throws JAXBException JAXBException
+   * @throws TrainingDatasetCreationError TrainingDatasetCreationError
+   */
+  public static Response createTrainingDatasetRest(
+    String featurestore, String trainingDataset, int trainingDatasetVersion, String description,
+    String jobName, String dataFormat, List<String> dependencies, List<FeatureDTO> featuresSchema,
+    StatisticsDTO statisticsDTO) throws JWTNotFoundException, JAXBException, TrainingDatasetCreationError {
+    LOG.log(Level.FINE, "Creating Training Dataset " + trainingDataset + " in featurestore: " + featurestore);
+    JSONObject json = new JSONObject();
+    json.put(Constants.JSON_FEATURESTORE_NAME, featurestore);
+    json.put(Constants.JSON_TRAINING_DATASET_NAME, trainingDataset);
+    json.put(Constants.JSON_TRAINING_DATASET_VERSION, trainingDatasetVersion);
+    json.put(Constants.JSON_TRAINING_DATASET_DESCRIPTION, description);
+    json.put(Constants.JSON_TRAINING_DATASET_JOBNAME, jobName);
+    json.put(Constants.JSON_TRAINING_DATASET_DEPENDENCIES, dependencies);
+    json.put(Constants.JSON_TRAINING_DATASET_FORMAT, dataFormat);
+    json.put(Constants.JSON_TRAINING_DATASET_SCHEMA,
+      FeaturestoreHelper.convertFeatureDTOsToJsonObjects(featuresSchema));
+    json.put(Constants.JSON_TRAINING_DATASET_FEATURE_CORRELATION,
+      FeaturestoreHelper.convertFeatureCorrelationMatrixDTOToJsonObject(
+        statisticsDTO.getFeatureCorrelationMatrixDTO()));
+    json.put(Constants.JSON_TRAINING_DATASET_DESC_STATS,
+      FeaturestoreHelper.convertDescriptiveStatsDTOToJsonObject(statisticsDTO.getDescriptiveStatsDTO()));
+    json.put(Constants.JSON_TRAINING_DATASET_FEATURES_HISTOGRAM, FeaturestoreHelper
+      .convertFeatureDistributionsDTOToJsonObject(statisticsDTO.getFeatureDistributionsDTO()));
+    json.put(Constants.JSON_TRAINING_DATASET_CLUSTER_ANALYSIS, FeaturestoreHelper
+      .convertClusterAnalysisDTOToJsonObject(statisticsDTO.getClusterAnalysisDTO()));
+    Response response;
+    try {
+      response = Hops.clientWrapper(json,
+        "/project/" + Hops.getProjectId() + "/" + Constants.HOPSWORKS_REST_FEATURESTORES_RESOURCE + "/" +
+          Constants.HOPSWORKS_REST_CREATE_TRAINING_DATASET_RESOURCE,
+        HttpMethod.POST);
+    } catch (HTTPSClientInitializationException e) {
+      throw new TrainingDatasetCreationError(e.getMessage());
+    }
+    LOG.log(Level.INFO, "******* response.getStatusInfo():" + response.getStatusInfo());
+    if (response.getStatusInfo().getStatusCode() != Response.Status.CREATED.getStatusCode()) {
+      HopsworksErrorResponseDTO hopsworksErrorResponseDTO = Hops.parseHopsworksErrorResponse(response);
+      throw new TrainingDatasetCreationError("Could not create trainingDataset:" + trainingDataset +
+        " , error code: " + hopsworksErrorResponseDTO.getErrorCode() + " error message: "
+        + hopsworksErrorResponseDTO.getErrorMsg() + ", user message: " + hopsworksErrorResponseDTO.getUserMsg());
+    }
+    return response;
+  }
+  
+  /**
+   * Makes a REST call to Hopsworks for getting the list of featurestores in the project
+   *
+   * @return the HTTP response
+   * @throws JWTNotFoundException JWTNotFoundException
+   * @throws FeaturestoresNotFound FeaturestoresNotFound
+   */
+  public static Response getFeaturestoresForProjectRest()
+    throws JWTNotFoundException, FeaturestoresNotFound {
+    LOG.log(Level.FINE, "Getting featurestores for current project");
+    
+    Response response;
+    try {
+      response =
+        Hops.clientWrapper("/project/" + Hops.getProjectId() + "/" + Constants.HOPSWORKS_REST_FEATURESTORES_RESOURCE,
+          HttpMethod.GET);
+    } catch (HTTPSClientInitializationException e) {
+      throw new FeaturestoresNotFound(e.getMessage());
+    }
+    LOG.log(Level.INFO, "******* response.getStatusInfo():" + response.getStatusInfo());
+    if (response.getStatusInfo().getStatusCode() != Response.Status.OK.getStatusCode()) {
+      throw new FeaturestoresNotFound("Could not fetch featurestores for the current project");
+    }
+    return response;
+  }
+  
+  /**
+   * Makes a REST call to Hopsworks for updating the statistics of a featuregroup
+   *
+   * @param featuregroup        the name of the featuregroup
+   * @param featurestore        the name of the featurestore where the featuregroup resides
+   * @param featuregroupVersion the version of the featuregroup
+   * @param statisticsDTO       the new statistics of the featuregroup
+   * @throws JWTNotFoundException JWTNotFoundException
+   * @throws JAXBException JAXBException
+   * @throws FeaturegroupUpdateStatsError FeaturegroupUpdateStatsError
+   */
+  public static void updateFeaturegroupStatsRest(
+    String featuregroup, String featurestore, int featuregroupVersion, StatisticsDTO statisticsDTO)
+    throws JWTNotFoundException,
+    JAXBException, FeaturegroupUpdateStatsError {
+    LOG.log(Level.FINE, "Updating featuregroup stats for: " + featuregroup + " in featurestore: " + featurestore);
+    JSONObject json = new JSONObject();
+    json.put(Constants.JSON_FEATURESTORE_NAME, featurestore);
+    json.put(Constants.JSON_FEATUREGROUP_NAME, featuregroup);
+    json.put(Constants.JSON_FEATUREGROUP_VERSION, featuregroupVersion);
+    json.put(Constants.JSON_FEATUREGROUP_FEATURE_CORRELATION,
+      FeaturestoreHelper.convertFeatureCorrelationMatrixDTOToJsonObject(
+        statisticsDTO.getFeatureCorrelationMatrixDTO()));
+    json.put(Constants.JSON_FEATUREGROUP_DESC_STATS,
+      FeaturestoreHelper.convertDescriptiveStatsDTOToJsonObject(statisticsDTO.getDescriptiveStatsDTO()));
+    json.put(Constants.JSON_FEATUREGROUP_FEATURES_HISTOGRAM, FeaturestoreHelper
+      .convertFeatureDistributionsDTOToJsonObject(statisticsDTO.getFeatureDistributionsDTO()));
+    json.put(Constants.JSON_FEATUREGROUP_CLUSTER_ANALYSIS, FeaturestoreHelper
+      .convertClusterAnalysisDTOToJsonObject(statisticsDTO.getClusterAnalysisDTO()));
+    json.put(Constants.JSON_FEATUREGROUP_UPDATE_METADATA, false);
+    json.put(Constants.JSON_FEATUREGROUP_UPDATE_STATS, true);
+    Response response;
+    try {
+      response = Hops.clientWrapper(json,
+        "/project/" + Hops.getProjectId() + "/" + Constants.HOPSWORKS_REST_FEATURESTORES_RESOURCE + "/" +
+          Constants.HOPSWORKS_REST_UPDATE_FEATUREGROUP_RESOURCE,
+        HttpMethod.PUT);
+    } catch (HTTPSClientInitializationException e) {
+      throw new FeaturegroupUpdateStatsError(e.getMessage());
+    }
+    LOG.log(Level.INFO, "******* response.getStatusInfo():" + response.getStatusInfo());
+    if (response.getStatusInfo().getStatusCode() != Response.Status.OK.getStatusCode()) {
+      HopsworksErrorResponseDTO hopsworksErrorResponseDTO = Hops.parseHopsworksErrorResponse(response);
+      throw new FeaturegroupUpdateStatsError("Could not update statistics for featuregroup:" + featuregroup +
+        " , error code: " + hopsworksErrorResponseDTO.getErrorCode() + " error message: "
+        + hopsworksErrorResponseDTO.getErrorMsg() + ", user message: " + hopsworksErrorResponseDTO.getUserMsg());
+    }
+  }
+  
+  /**
+   * @param trainingDataset        the name of the training dataset
+   * @param featurestore           the name of the featurestore where the training dataset resides
+   * @param trainingDatasetVersion the version of the training dataset
+   * @param statisticsDTO          the new statistics of the training dataset
+   * @return the JSON response
+   * @throws JWTNotFoundException JWTNotFoundException
+   * @throws JAXBException JAXBException
+   * @throws FeaturegroupUpdateStatsError FeaturegroupUpdateStatsError
+   */
+  public static Response updateTrainingDatasetStatsRest(
+    String trainingDataset, String featurestore, int trainingDatasetVersion, StatisticsDTO statisticsDTO)
+    throws JWTNotFoundException,
+    JAXBException, FeaturegroupUpdateStatsError {
+    LOG.log(Level.FINE, "Updating training dataset stats for: " + trainingDataset +
+      " in featurestore: " + featurestore);
+    JSONObject json = new JSONObject();
+    json.put(Constants.JSON_FEATURESTORE_NAME, featurestore);
+    json.put(Constants.JSON_TRAINING_DATASET_NAME, trainingDataset);
+    json.put(Constants.JSON_TRAINING_DATASET_VERSION, trainingDatasetVersion);
+    json.put(Constants.JSON_TRAINING_DATASET_FEATURE_CORRELATION,
+      FeaturestoreHelper.convertFeatureCorrelationMatrixDTOToJsonObject(
+        statisticsDTO.getFeatureCorrelationMatrixDTO()));
+    json.put(Constants.JSON_TRAINING_DATASET_DESC_STATS,
+      FeaturestoreHelper.convertDescriptiveStatsDTOToJsonObject(statisticsDTO.getDescriptiveStatsDTO()));
+    json.put(Constants.JSON_TRAINING_DATASET_FEATURES_HISTOGRAM, FeaturestoreHelper
+      .convertFeatureDistributionsDTOToJsonObject(statisticsDTO.getFeatureDistributionsDTO()));
+    json.put(Constants.JSON_TRAINING_DATASET_CLUSTER_ANALYSIS, FeaturestoreHelper
+      .convertClusterAnalysisDTOToJsonObject(statisticsDTO.getClusterAnalysisDTO()));
+    json.put(Constants.JSON_TRAINING_DATASET_UPDATE_METADATA, false);
+    json.put(Constants.JSON_FEATUREGROUP_UPDATE_STATS, true);
+    Response response = null;
+    try {
+      response = Hops.clientWrapper(json,
+        "/project/" + Hops.getProjectId() + "/" + Constants.HOPSWORKS_REST_FEATURESTORES_RESOURCE + "/" +
+          Constants.HOPSWORKS_REST_UPDATE_TRAINING_DATASET_RESOURCE,
+        HttpMethod.PUT);
+    } catch (HTTPSClientInitializationException e) {
+      throw new FeaturegroupUpdateStatsError(e.getMessage());
+    }
+    LOG.log(Level.INFO, "******* response.getStatusInfo():" + response.getStatusInfo());
+    if (response.getStatusInfo().getStatusCode() != Response.Status.OK.getStatusCode()) {
+      HopsworksErrorResponseDTO hopsworksErrorResponseDTO = Hops.parseHopsworksErrorResponse(response);
+      throw new FeaturegroupUpdateStatsError("Could not update statistics for trainingDataset:" + trainingDataset +
+        " , error code: " + hopsworksErrorResponseDTO.getErrorCode() + " error message: "
+        + hopsworksErrorResponseDTO.getErrorMsg() + ", user message: " + hopsworksErrorResponseDTO.getUserMsg());
+    }
+    return response;
+  }
+}
+

--- a/src/main/java/io/hops/util/featurestore/ops/FeaturestoreOp.java
+++ b/src/main/java/io/hops/util/featurestore/ops/FeaturestoreOp.java
@@ -1,0 +1,285 @@
+package io.hops.util.featurestore.ops;
+
+import io.hops.util.Hops;
+import io.hops.util.exceptions.CannotWriteImageDataFrameException;
+import io.hops.util.exceptions.DataframeIsEmpty;
+import io.hops.util.exceptions.FeaturegroupCreationError;
+import io.hops.util.exceptions.FeaturegroupDeletionError;
+import io.hops.util.exceptions.FeaturegroupUpdateStatsError;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.exceptions.FeaturestoresNotFound;
+import io.hops.util.exceptions.InvalidPrimaryKeyForFeaturegroup;
+import io.hops.util.exceptions.JWTNotFoundException;
+import io.hops.util.exceptions.SparkDataTypeNotRecognizedError;
+import io.hops.util.exceptions.TrainingDatasetCreationError;
+import io.hops.util.exceptions.TrainingDatasetDoesNotExistError;
+import io.hops.util.exceptions.TrainingDatasetFormatNotSupportedError;
+import io.hops.util.featurestore.FeaturestoreHelper;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+import javax.xml.bind.JAXBException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Abstract feature store operation, uses builder-pattern for concrete operation implementations
+ */
+public abstract class FeaturestoreOp {
+  
+  protected String name;
+  protected SparkSession spark = Hops.findSpark();
+  protected String featurestore = FeaturestoreHelper.featurestoreGetOrDefault(null);
+  protected int version = 1;
+  protected String featuregroup;
+  protected List<String> features;
+  protected Map<String, Integer> featuregroupsAndVersions;
+  protected String joinKey;
+  protected String corrMethod = FeaturestoreHelper.correlationMethodGetOrDefault(null);
+  protected int numBins = FeaturestoreHelper.numBinsGetOrDefault(null);
+  protected int numClusters = FeaturestoreHelper.numClustersGetOrDefault(null);
+  protected String mode;
+  protected Dataset<Row> dataframe;
+  protected Boolean descriptiveStats = true;
+  protected Boolean featureCorr = true;
+  protected Boolean featureHistograms = true;
+  protected Boolean clusterAnalysis = true;
+  protected List<String> statColumns = null;
+  protected String jobName = FeaturestoreHelper.jobNameGetOrDefault(null);
+  protected String primaryKey;
+  protected String description = "";
+  protected List<String> dependencies = new ArrayList<>();
+  protected String dataFormat = FeaturestoreHelper.dataFormatGetOrDefault(null);
+  
+  /**
+   * Class constructor
+   *
+   * @param name name of featuregroup/feature/training dataset that the operation concerns. Empty string if the
+   *             the operation is applied to the entire featurestore.
+   */
+  public FeaturestoreOp(String name) {
+    this.name = name;
+  }
+  
+  /**
+   * Class constructor
+   *
+   * @param features list of features that the operation concerns, empty list or null if it does not concert any
+   *                 list of features
+   */
+  public FeaturestoreOp(List<String> features) {
+    this.features = features;
+  }
+  
+  
+  /**
+   *
+   * @return name of featuregroup/feature/training dataset that the operation concerns. Empty string if the
+   *         the operation is applied to the entire featurestore.
+   */
+  public String getName() {
+    return name;
+  }
+  
+  /**
+   * @return spark session to use for the operation
+   */
+  public SparkSession getSpark() {
+    return spark;
+  }
+  
+  /**
+   *
+   * @return featurestore to apply the operation on
+   */
+  public String getFeaturestore() {
+    return featurestore;
+  }
+  
+  /**
+   *
+   * @return version of the featuregroup/training dataset that the operation concerns
+   */
+  public int getVersion() {
+    return version;
+  }
+  
+  /**
+   * @return The featuregroup used for queries of features
+   */
+  public String getFeaturegroup() {
+    return featuregroup;
+  }
+  
+  /**
+   * @return List of features to use in the query
+   */
+  public List<String> getFeatures() {
+    return features;
+  }
+  
+  /**
+   * @return a map with featuregroups and their versions
+   */
+  public Map<String, Integer> getFeaturegroupsAndVersions() {
+    return featuregroupsAndVersions;
+  }
+  
+  /**
+   * @return the join key to use for the query
+   */
+  public String getJoinKey() {
+    return joinKey;
+  }
+  
+  /**
+   * @return the correlation method to use for feature correlation analysis (e.g pearson or spearman)
+   */
+  public String getCorrMethod() {
+    return corrMethod;
+  }
+  
+  /**
+   * @return the number of bins to use for histogram statistics
+   */
+  public int getNumBins() {
+    return numBins;
+  }
+  
+  /**
+   * @return the number of clusters to use for k-means clustering analysis
+   */
+  public int getNumClusters() {
+    return numClusters;
+  }
+  
+  /**
+   * @return the write mode (append or overwrite)
+   */
+  public String getMode() {
+    return mode;
+  }
+  
+  /**
+   * @return the dataframe to use for write operations
+   */
+  public Dataset<Row> getDataframe() {
+    return dataframe;
+  }
+  
+  /**
+   * @return boolean flag indicating whether descriptive stats should be computed for statistics update
+   */
+  public Boolean getDescriptiveStats() {
+    return descriptiveStats;
+  }
+  
+  /**
+   * @return boolean flag indicating whether feature correlation should be computed for statistics update
+   */
+  public Boolean getFeatureCorr() {
+    return featureCorr;
+  }
+  
+  /**
+   * @return boolean flag indicating whether feature histograms should be computed for statistics update
+   */
+  public Boolean getFeatureHistograms() {
+    return featureHistograms;
+  }
+  
+  /**
+   * @return boolean flag indicating whether cluster analysis should be computed for statistics update
+   */
+  public Boolean getClusterAnalysis() {
+    return clusterAnalysis;
+  }
+  
+  /**
+   * @return a list of columns to compute statistics for (defaults to all columns that are numeric)
+   */
+  public List<String> getStatColumns() {
+    return statColumns;
+  }
+  
+  /**
+   * @return name of the job to compute the feature group or training dataset
+   */
+  public String getJobName() {
+    return jobName;
+  }
+  
+  /**
+   * @return the primary key of the new featuregroup, if not specified, the first column in the
+   * dataframe will be used as primary
+   */
+  public String getPrimaryKey() {
+    return primaryKey;
+  }
+  
+  /**
+   * @return a description of the featuregroup/training dataset
+   */
+  public String getDescription() {
+    return description;
+  }
+  
+  /**
+   * @return list of the datasets that this featuregroup depends on (e.g input datasets to the feature engineering job)
+   */
+  public List<String> getDependencies() {
+    return dependencies;
+  }
+  
+  /**
+   * @return the format of the materialized training dataset
+   */
+  public String getDataFormat() {
+    return dataFormat;
+  }
+  
+  /**
+   * Abstract read method, implemented by sub-classes for different feature store read-operations
+   * This method is called by the user after populating parameters of the operation
+   *
+   * @return An object with results(typically a dataframe or list)
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   * @throws JAXBException JAXBException
+   * @throws TrainingDatasetFormatNotSupportedError TrainingDatasetFormatNotSupportedError
+   * @throws TrainingDatasetDoesNotExistError TrainingDatasetDoesNotExistError
+   * @throws IOException IOException
+   * @throws FeaturestoresNotFound FeaturestoresNotFound
+   * @throws JWTNotFoundException JWTNotFoundException
+   */
+  public abstract Object read()
+    throws FeaturestoreNotFound, JAXBException, TrainingDatasetFormatNotSupportedError,
+    TrainingDatasetDoesNotExistError, IOException, FeaturestoresNotFound, JWTNotFoundException;
+  
+  /**
+   * Abstract write operation, implemented by sub-classes for different feature store write-operations.
+   * This method is called by the user after populating parameters of the operation
+   *
+   * @throws FeaturegroupDeletionError FeaturegroupDeletionError
+   * @throws DataframeIsEmpty DataframeIsEmpty
+   * @throws SparkDataTypeNotRecognizedError SparkDataTypeNotRecognizedError
+   * @throws JAXBException JAXBException
+   * @throws FeaturegroupUpdateStatsError FeaturegroupUpdateStatsError
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   * @throws TrainingDatasetDoesNotExistError TrainingDatasetDoesNotExistError
+   * @throws TrainingDatasetFormatNotSupportedError TrainingDatasetFormatNotSupportedError
+   * @throws IOException IOException
+   * @throws InvalidPrimaryKeyForFeaturegroup InvalidPrimaryKeyForFeaturegroup
+   * @throws FeaturegroupCreationError FeaturegroupCreationError
+   * @throws TrainingDatasetCreationError TrainingDatasetCreationError
+   * @throws CannotWriteImageDataFrameException CannotWriteImageDataFrameException
+   * @throws JWTNotFoundException JWTNotFoundException
+   */
+  public abstract void write()
+    throws FeaturegroupDeletionError, DataframeIsEmpty, SparkDataTypeNotRecognizedError,
+    JAXBException, FeaturegroupUpdateStatsError, FeaturestoreNotFound, TrainingDatasetDoesNotExistError,
+    TrainingDatasetFormatNotSupportedError, IOException, InvalidPrimaryKeyForFeaturegroup, FeaturegroupCreationError,
+    TrainingDatasetCreationError, CannotWriteImageDataFrameException, JWTNotFoundException;
+}

--- a/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadFeature.java
+++ b/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadFeature.java
@@ -1,0 +1,102 @@
+package io.hops.util.featurestore.ops.read_ops;
+
+import com.google.common.base.Strings;
+import io.hops.util.Hops;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.featurestore.FeaturegroupsAndTrainingDatasetsDTO;
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.featuregroup.FeaturegroupDTO;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+import javax.xml.bind.JAXBException;
+import java.util.List;
+
+/**
+ * Builder class for Read-Feature operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreReadFeature extends FeaturestoreOp {
+  
+  /**
+   * Constructor
+   *
+   * @param name name of the feature to read
+   */
+  public FeaturestoreReadFeature(String name) {
+    super(name);
+  }
+  
+  /**
+   * Gets a feature from a featurestore and a specific featuregroup.
+   *
+   * @return a spark dataframe with the feature
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   * @throws JAXBException JAXBException
+   */
+  public Dataset<Row> read() throws FeaturestoreNotFound, JAXBException {
+    try {
+      return doGetFeature(spark, name, Hops.getFeaturestoreMetadata().setFeaturestore(featurestore).read(),
+        featurestore);
+    } catch (Exception e) {
+      Hops.updateFeaturestoreMetadataCache().setFeaturestore(featurestore).write();
+      return doGetFeature(spark, name, Hops.getFeaturestoreMetadata().setFeaturestore(featurestore).read()
+        , featurestore);
+    }
+  }
+  
+  /**
+   * Method call to execute write operation
+   */
+  public void write(){
+    throw new UnsupportedOperationException("write() is not supported on a read operation");
+  }
+  
+  /**
+   * Gets a feature from a featurestore and infers the featuregroup where the feature is located
+   *
+   * @param sparkSession the spark session
+   * @param feature      the feature to get
+   * @param featurestoreMetadata metadata of the featurestore to query
+   * @param featurestore the featurestore to query
+   * @return A dataframe with the feature
+   */
+  private Dataset<Row> doGetFeature(
+    SparkSession sparkSession, String feature,
+    FeaturegroupsAndTrainingDatasetsDTO featurestoreMetadata, String featurestore) {
+    sparkSession = FeaturestoreHelper.sparkGetOrDefault(sparkSession);
+    List<FeaturegroupDTO> featuregroupsMetadata = featurestoreMetadata.getFeaturegroups();
+    if(Strings.isNullOrEmpty(featuregroup)) {
+      return FeaturestoreHelper.getFeature(sparkSession, feature, featurestore, featuregroupsMetadata);
+    } else {
+      return FeaturestoreHelper.getFeature(sparkSession, feature, featurestore, featuregroup, version);
+    }
+  }
+  
+  public FeaturestoreReadFeature setSpark(SparkSession spark) {
+    this.spark = spark;
+    return this;
+  }
+  
+  public FeaturestoreReadFeature setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+    return this;
+  }
+  
+  public FeaturestoreReadFeature setVersion(int version) {
+    this.version = version;
+    return this;
+  }
+  
+  public FeaturestoreReadFeature setName(String name) {
+    this.name = name;
+    return this;
+  }
+  
+  public FeaturestoreReadFeature setFeaturegroup(String featuregroup) {
+    this.featuregroup = featuregroup;
+    return this;
+  }
+  
+}

--- a/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadFeaturegroup.java
+++ b/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadFeaturegroup.java
@@ -1,0 +1,59 @@
+package io.hops.util.featurestore.ops.read_ops;
+
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+/**
+ * Builder class for Read-Featuregroup operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreReadFeaturegroup extends FeaturestoreOp {
+  
+  /**
+   * Constructor
+   *
+   * @param name name of the featuregroup to read
+   */
+  public FeaturestoreReadFeaturegroup(String name) {
+    super(name);
+  }
+  
+  /**
+   * Gets a featuregroup from a particular featurestore
+   *
+   * @return a spark dataframe with the featuregroup
+   */
+  public Dataset<Row> read() {
+    return FeaturestoreHelper.getFeaturegroup(spark, name, featurestore, version);
+  }
+  
+  /**
+   * Method call to execute write operation
+   */
+  public void write(){
+    throw new UnsupportedOperationException("write() is not supported on a read operation");
+  }
+  
+  public FeaturestoreReadFeaturegroup setName(String name) {
+    this.name = name;
+    return this;
+  }
+  
+  public FeaturestoreReadFeaturegroup setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+    return this;
+  }
+  
+  public FeaturestoreReadFeaturegroup setSpark(SparkSession spark) {
+    this.spark = spark;
+    return this;
+  }
+  
+  public FeaturestoreReadFeaturegroup setVersion(int version) {
+    this.version = version;
+    return this;
+  }
+  
+}

--- a/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadFeaturegroupLatestVersion.java
+++ b/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadFeaturegroupLatestVersion.java
@@ -1,0 +1,69 @@
+package io.hops.util.featurestore.ops.read_ops;
+
+import io.hops.util.Hops;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.featurestore.FeaturegroupsAndTrainingDatasetsDTO;
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.featuregroup.FeaturegroupDTO;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+
+import javax.xml.bind.JAXBException;
+import java.util.List;
+
+/**
+ * Builder class for Read-LatestFeaturegroupVersion operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreReadFeaturegroupLatestVersion extends FeaturestoreOp {
+  
+  /**
+   * Constructor
+   *
+   * @param name name of the featuregroup
+   */
+  public FeaturestoreReadFeaturegroupLatestVersion(String name) {
+    super(name);
+  }
+  
+  /**
+   * Gets the latest version of a featuregroup in the featurestore
+   *
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   * @throws JAXBException JAXBException
+   * @return the latest version of the featuregroup
+   */
+  public Integer read() throws FeaturestoreNotFound, JAXBException {
+    try {
+      return doGetLatestFeaturegroupVersion(name, Hops.getFeaturestoreMetadata().setFeaturestore(featurestore).read());
+    } catch (Exception e) {
+      Hops.updateFeaturestoreMetadataCache().setFeaturestore(featurestore).write();
+      return doGetLatestFeaturegroupVersion(name, Hops.getFeaturestoreMetadata().setFeaturestore(featurestore).read());
+    }
+  }
+  
+  /**
+   * Method call to execute write operation
+   */
+  public void write(){
+    throw new UnsupportedOperationException("write() is not supported on a read operation");
+  }
+  
+  public FeaturestoreReadFeaturegroupLatestVersion setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+    return this;
+  }
+  
+  
+  /**
+   * Extrects the latest version of a featuregroup from the metadata
+   *
+   * @param featuregroupName name of the featuregroup
+   * @param featurestoreMetadata metadata of the featurestore
+   * @return the latest version of the feature group
+   */
+  private static int doGetLatestFeaturegroupVersion(
+    String featuregroupName, FeaturegroupsAndTrainingDatasetsDTO featurestoreMetadata) {
+    List<FeaturegroupDTO> featuregroupDTOList = featurestoreMetadata.getFeaturegroups();
+    return FeaturestoreHelper.getLatestFeaturegroupVersion(featuregroupDTOList, featuregroupName);
+  }
+  
+}

--- a/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadFeaturegroups.java
+++ b/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadFeaturegroups.java
@@ -1,0 +1,49 @@
+package io.hops.util.featurestore.ops.read_ops;
+
+import io.hops.util.Hops;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+
+import javax.xml.bind.JAXBException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Builder class for Read-Featuregroups operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreReadFeaturegroups extends FeaturestoreOp {
+  
+  /**
+   * Constructor
+   */
+  public FeaturestoreReadFeaturegroups() {
+    super("");
+  }
+  
+  /**
+   * Gets a list of all featuregroups from a particular featurestore
+   *
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   * @throws JAXBException JAXBException
+   * @return a list of the featuregroups
+   */
+  public List<String> read() throws FeaturestoreNotFound, JAXBException {
+    return Hops.getFeaturestoreMetadata().setFeaturestore(featurestore).read()
+      .getFeaturegroups().stream()
+      .map(fg -> FeaturestoreHelper.getTableName(fg.getName(), fg.getVersion())).collect(Collectors.toList());
+  }
+  
+  /**
+   * Method call to execute write operation
+   */
+  public void write(){
+    throw new UnsupportedOperationException("write() is not supported on a read operation");
+  }
+  
+  public FeaturestoreReadFeaturegroups setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+    return this;
+  }
+  
+}

--- a/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadFeatures.java
+++ b/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadFeatures.java
@@ -1,0 +1,168 @@
+package io.hops.util.featurestore.ops.read_ops;
+
+import com.google.common.base.Strings;
+import io.hops.util.Hops;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.featurestore.FeaturegroupsAndTrainingDatasetsDTO;
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.featuregroup.FeaturegroupDTO;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+import javax.xml.bind.JAXBException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builder class for Read-Features operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreReadFeatures extends FeaturestoreOp {
+  
+  /**
+   * Constructor
+   *
+   * @param features list of feature names to read
+   */
+  public FeaturestoreReadFeatures(List<String> features) {
+    super(features);
+  }
+  
+  /**
+   * Gets a feature from a featurestore and a specific featuregroup.
+   *
+   * @return a spark dataframe with the feature
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   * @throws JAXBException JAXBException
+   */
+  public Dataset<Row> read() throws FeaturestoreNotFound, JAXBException {
+    if(features.isEmpty()){
+      throw new IllegalArgumentException("Feature List Cannot be Empty");
+    }
+    try {
+      return doGetFeatures();
+    } catch (Exception e){
+      Hops.updateFeaturestoreMetadataCache().setFeaturestore(featurestore).write();
+      return doGetFeatures();
+    }
+  }
+  
+  /**
+   * Gets a list of features from the featurestore
+   *
+   * @return A spark dataframe with the features
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   * @throws JAXBException JAXBException
+   */
+  private Dataset<Row> doGetFeatures() throws FeaturestoreNotFound, JAXBException {
+    if(!Strings.isNullOrEmpty(joinKey) && featuregroupsAndVersions != null){
+      return FeaturestoreHelper.getFeatures(spark, features, featurestore, featuregroupsAndVersions, joinKey);
+    }
+    if(!Strings.isNullOrEmpty(joinKey) && featuregroupsAndVersions == null){
+      return doGetFeatures(spark, features, featurestore,
+        Hops.getFeaturestoreMetadata().setFeaturestore(featurestore).read(), joinKey);
+    }
+    if(Strings.isNullOrEmpty(joinKey) && featuregroupsAndVersions != null){
+      return doGetFeatures(spark, features, featurestore, Hops.getFeaturestoreMetadata()
+          .setFeaturestore(featurestore).read(), featuregroupsAndVersions);
+    }
+    return doGetFeatures(spark, features, featurestore, Hops.getFeaturestoreMetadata()
+      .setFeaturestore(featurestore).read());
+  }
+  
+  /**
+   * Method call to execute write operation
+   */
+  public void write(){
+    throw new UnsupportedOperationException("write() is not supported on a read operation");
+  }
+  
+  /**
+   * Gets a set of features from a featurestore and returns them as a Spark dataframe. This method is used if the user
+   * has itself provided a set of featuregroups where the features are located and should be queried from
+   * but not a join key, it does not infer the featuregroups but infers the join key
+   *
+   * @param sparkSession             the spark session
+   * @param features                 the list of features to get
+   * @param featurestore             the featurestore to query
+   * @param featurestoreMetadata     metadata of the featurestore to query
+   * @param featuregroupsAndVersions a map of (featuregroup to version) where the featuregroups are located
+   * @return a spark dataframe with the features
+   */
+  private Dataset<Row> doGetFeatures(
+    SparkSession sparkSession, List<String> features, String featurestore,
+    FeaturegroupsAndTrainingDatasetsDTO featurestoreMetadata,
+    Map<String, Integer> featuregroupsAndVersions) {
+    List<FeaturegroupDTO> featuregroupsMetadata = featurestoreMetadata.getFeaturegroups();
+    List<FeaturegroupDTO> filteredFeaturegroupsMetadata =
+      FeaturestoreHelper.filterFeaturegroupsBasedOnMap(featuregroupsAndVersions, featuregroupsMetadata);
+    String joinKey = FeaturestoreHelper.getJoinColumn(filteredFeaturegroupsMetadata);
+    return FeaturestoreHelper.getFeatures(sparkSession, features, featurestore, featuregroupsAndVersions, joinKey);
+  }
+  
+  /**
+   * Gets a set of features from a featurestore and returns them as a Spark dataframe. This method will infer
+   * in which featuregroups the features belong but uses a user-supplied join key
+   *
+   * @param sparkSession the spark session
+   * @param features     the list of features to get
+   * @param featurestore the featurestore to query
+   * @param featurestoreMetadata metadata of the featurestore to query
+   * @param joinKey      the key to join on
+   * @return a spark dataframe with the features
+   */
+  private Dataset<Row> doGetFeatures(
+    SparkSession sparkSession, List<String> features,
+    String featurestore, FeaturegroupsAndTrainingDatasetsDTO featurestoreMetadata, String joinKey) {
+    List<FeaturegroupDTO> featuregroupsMetadata = featurestoreMetadata.getFeaturegroups();
+    return FeaturestoreHelper.getFeatures(sparkSession, features, featurestore, featuregroupsMetadata, joinKey);
+  }
+  
+  /**
+   * Gets a set of features from a featurestore and returns them as a Spark dataframe. This method will infer
+   * in which featuregroups the features belong and which join_key to use using metadata from the metastore
+   *
+   * @param sparkSession the spark session
+   * @param features     the list of features to get
+   * @param featurestore the featurestore to query
+   * @param featurestoreMetadata metadata of which features exist in the featurestore, used to infer how to join
+   *                             features together
+   * @return a spark dataframe with the features
+   */
+  private static Dataset<Row> doGetFeatures(
+    SparkSession sparkSession, List<String> features,
+    String featurestore, FeaturegroupsAndTrainingDatasetsDTO featurestoreMetadata) {
+    List<FeaturegroupDTO> featuregroupsMetadata = featurestoreMetadata.getFeaturegroups();
+    List<FeaturegroupDTO> featuregroupsMatching =
+      FeaturestoreHelper.findFeaturegroupsThatContainsFeatures(featuregroupsMetadata, features, featurestore);
+    String joinKey = FeaturestoreHelper.getJoinColumn(featuregroupsMatching);
+    return FeaturestoreHelper.getFeatures(sparkSession, features, featurestore, featuregroupsMatching, joinKey);
+  }
+  
+  public FeaturestoreReadFeatures setFeatures(List<String> features) {
+    this.features = features;
+    return this;
+  }
+  
+  public FeaturestoreReadFeatures setSpark(SparkSession spark) {
+    this.spark = spark;
+    return this;
+  }
+  
+  public FeaturestoreReadFeatures setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+    return this;
+  }
+  
+  public FeaturestoreReadFeatures setFeaturegroupsAndVersions(Map<String, Integer> featuregroupsAndVersions) {
+    this.featuregroupsAndVersions = featuregroupsAndVersions;
+    return this;
+  }
+  
+  public FeaturestoreReadFeatures setJoinKey(String joinKey) {
+    this.joinKey = joinKey;
+    return this;
+  }
+  
+}

--- a/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadFeaturesList.java
+++ b/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadFeaturesList.java
@@ -1,0 +1,53 @@
+package io.hops.util.featurestore.ops.read_ops;
+
+import io.hops.util.Hops;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+
+import javax.xml.bind.JAXBException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Builder class for Read-FeaturesList operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreReadFeaturesList extends FeaturestoreOp {
+  
+  /**
+   * Constructor
+   */
+  public FeaturestoreReadFeaturesList() {
+    super("");
+  }
+  
+  /**
+   * Gets a list of all features from a particular featurestore
+   *
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   * @throws JAXBException JAXBException
+   * @return a spark dataframe with the featuregroup
+   */
+  public List<String> read() throws FeaturestoreNotFound, JAXBException {
+    List<List<String>> featureNamesLists = Hops.getFeaturestoreMetadata().setFeaturestore(featurestore)
+      .read().getFeaturegroups().stream()
+      .map(fg -> fg.getFeatures().stream().map(f -> f.getName())
+        .collect(Collectors.toList())).collect(Collectors.toList());
+    List<String> featureNames = new ArrayList<>();
+    featureNamesLists.stream().forEach(flist -> featureNames.addAll(flist));
+    return featureNames;
+  }
+  
+  /**
+   * Method call to execute write operation
+   */
+  public void write(){
+    throw new UnsupportedOperationException("write() is not supported on a read operation");
+  }
+  
+  public FeaturestoreReadFeaturesList setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+    return this;
+  }
+  
+}

--- a/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadMetadata.java
+++ b/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadMetadata.java
@@ -1,0 +1,50 @@
+package io.hops.util.featurestore.ops.read_ops;
+
+import io.hops.util.Hops;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.featurestore.FeaturegroupsAndTrainingDatasetsDTO;
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+
+import javax.xml.bind.JAXBException;
+
+/**
+ * Builder class for Read-metadata operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreReadMetadata extends FeaturestoreOp {
+  
+  /**
+   * Constructor
+   */
+  public FeaturestoreReadMetadata() {
+    super("");
+  }
+  
+  /**
+   * Gets featurestore metadata
+   *
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   * @throws JAXBException JAXBException
+   * @return a spark dataframe with the featuregroup
+   */
+  public FeaturegroupsAndTrainingDatasetsDTO read() throws FeaturestoreNotFound,
+    JAXBException {
+    if(FeaturestoreHelper.getFeaturestoreMetadataCache() == null){
+      Hops.updateFeaturestoreMetadataCache().setFeaturestore(featurestore).write();
+    }
+    return FeaturestoreHelper.getFeaturestoreMetadataCache();
+  }
+  
+  /**
+   * Method call to execute write operation
+   */
+  public void write(){
+    throw new UnsupportedOperationException("write() is not supported on a read operation");
+  }
+  
+  public FeaturestoreReadMetadata setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+    return this;
+  }
+  
+}

--- a/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadProjectFeaturestore.java
+++ b/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadProjectFeaturestore.java
@@ -1,0 +1,34 @@
+package io.hops.util.featurestore.ops.read_ops;
+
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+
+/**
+ * Builder class for Read-ProjectFeaturestore operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreReadProjectFeaturestore extends FeaturestoreOp {
+  
+  /**
+   * Constructor
+   */
+  public FeaturestoreReadProjectFeaturestore() {
+    super("");
+  }
+  
+  /**
+   * Gets the project's featurestore name (project_featurestore)
+   *
+   * @return the featurestore name (hive db)
+   */
+  public String read() {
+    return FeaturestoreHelper.getProjectFeaturestore();
+  }
+  
+  /**
+   * Method call to execute write operation
+   */
+  public void write(){
+    throw new UnsupportedOperationException("write() is not supported on a read operation");
+  }
+  
+}

--- a/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadProjectFeaturestores.java
+++ b/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadProjectFeaturestores.java
@@ -1,0 +1,65 @@
+package io.hops.util.featurestore.ops.read_ops;
+
+import io.hops.util.Constants;
+import io.hops.util.FeaturestoreRestClient;
+import io.hops.util.Hops;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.exceptions.FeaturestoresNotFound;
+import io.hops.util.exceptions.JWTNotFoundException;
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import javax.ws.rs.core.Response;
+import javax.xml.bind.JAXBException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builder class for Read-List-of-Featurestores operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreReadProjectFeaturestores extends FeaturestoreOp {
+  
+  /**
+   * Constructor
+   */
+  public FeaturestoreReadProjectFeaturestores() {
+    super("");
+  }
+  
+  /**
+   * Gets a list of featurestores accessible in the project (i.e the project's own featurestore
+   * and the featurestores shared with the project)
+   *
+   * @return a list of names of the featurestores accessible by this project
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   * @throws JAXBException JAXBException
+   * @throws FeaturestoresNotFound FeaturestoresNotFound
+   * @throws JWTNotFoundException JWTNotFoundException
+   */
+  public List<String> read() throws FeaturestoreNotFound,
+    JAXBException, FeaturestoresNotFound, JWTNotFoundException {
+    if(FeaturestoreHelper.getFeaturestoreMetadataCache() == null){
+      Hops.updateFeaturestoreMetadataCache().setFeaturestore(featurestore).write();
+    }
+    Response response = FeaturestoreRestClient.getFeaturestoresForProjectRest();
+    final String responseEntity = response.readEntity(String.class);
+    JSONArray featurestoresJson = new JSONArray(responseEntity);
+    List<String> featurestores = new ArrayList();
+    for (int i = 0; i < featurestoresJson.length(); i++) {
+      JSONObject featurestoreJson = featurestoresJson.getJSONObject(i);
+      String featurestoreName = featurestoreJson.getString(Constants.JSON_FEATURESTORE_NAME);
+      featurestores.add(featurestoreName);
+    }
+    return featurestores;
+  }
+  
+  /**
+   * Method call to execute write operation
+   */
+  public void write(){
+    throw new UnsupportedOperationException("write() is not supported on a read operation");
+  }
+  
+}

--- a/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadTrainingDataset.java
+++ b/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadTrainingDataset.java
@@ -1,0 +1,111 @@
+package io.hops.util.featurestore.ops.read_ops;
+
+import io.hops.util.Constants;
+import io.hops.util.Hops;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.exceptions.TrainingDatasetDoesNotExistError;
+import io.hops.util.exceptions.TrainingDatasetFormatNotSupportedError;
+import io.hops.util.featurestore.FeaturegroupsAndTrainingDatasetsDTO;
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+import io.hops.util.featurestore.trainingdataset.TrainingDatasetDTO;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+import javax.xml.bind.JAXBException;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Builder class for Read-TrainingDataset operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreReadTrainingDataset extends FeaturestoreOp {
+  
+  /**
+   * Constructor
+   *
+   * @param name name of the training dataset to read
+   */
+  public FeaturestoreReadTrainingDataset(String name) {
+    super(name);
+  }
+  
+  /**
+   * Gets a training dataset from a particular featurestore
+   *
+   * @return a spark dataframe with the training dataset
+   * @throws FeaturestoreNotFound
+   * @throws JAXBException
+   * @throws TrainingDatasetFormatNotSupportedError
+   * @throws TrainingDatasetDoesNotExistError
+   * @throws IOException
+   */
+  public Dataset<Row> read()
+    throws FeaturestoreNotFound, JAXBException, TrainingDatasetFormatNotSupportedError,
+    TrainingDatasetDoesNotExistError, IOException {
+    try {
+      return doGetTrainingDataset(spark, name, Hops.getFeaturestoreMetadata()
+        .setFeaturestore(featurestore).read(), version);
+    } catch(Exception e) {
+      Hops.updateFeaturestoreMetadataCache().setFeaturestore(featurestore).write();
+      return doGetTrainingDataset(spark, name, Hops.getFeaturestoreMetadata()
+        .setFeaturestore(featurestore).read(), version);
+    }
+  }
+  
+  /**
+   * Method call to execute write operation
+   */
+  public void write(){
+    throw new UnsupportedOperationException("write() is not supported on a read operation");
+  }
+  
+  /**
+   * Gets a training dataset from a featurestore
+   *
+   * @param sparkSession           the spark session
+   * @param trainingDataset        the training dataset to get
+   * @param featurestoreMetadata   metadata of the featurestore to query
+   * @param trainingDatasetVersion the version of the training dataset
+   * @return a spark dataframe with the training dataset
+   * @throws TrainingDatasetDoesNotExistError TrainingDatasetDoesNotExistError
+   * @throws TrainingDatasetFormatNotSupportedError TrainingDatasetFormatNotSupportedError
+   * @throws IOException IOException
+   */
+  private Dataset<Row> doGetTrainingDataset(
+    SparkSession sparkSession, String trainingDataset,
+    FeaturegroupsAndTrainingDatasetsDTO featurestoreMetadata, int trainingDatasetVersion)
+    throws TrainingDatasetDoesNotExistError,
+    TrainingDatasetFormatNotSupportedError, IOException {
+    sparkSession = FeaturestoreHelper.sparkGetOrDefault(sparkSession);
+    List<TrainingDatasetDTO> trainingDatasetDTOList = featurestoreMetadata.getTrainingDatasets();
+    TrainingDatasetDTO trainingDatasetDTO = FeaturestoreHelper.findTrainingDataset(trainingDatasetDTOList,
+      trainingDataset, trainingDatasetVersion);
+    String hdfsPath = Constants.HDFS_DEFAULT + trainingDatasetDTO.getHdfsStorePath() +
+      Constants.SLASH_DELIMITER + trainingDatasetDTO.getName();
+    return FeaturestoreHelper.getTrainingDataset(sparkSession, trainingDatasetDTO.getDataFormat(),
+      hdfsPath);
+  }
+  
+  public FeaturestoreReadTrainingDataset setName(String name) {
+    this.name = name;
+    return this;
+  }
+  
+  public FeaturestoreReadTrainingDataset setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+    return this;
+  }
+  
+  public FeaturestoreReadTrainingDataset setSpark(SparkSession spark) {
+    this.spark = spark;
+    return this;
+  }
+  
+  public FeaturestoreReadTrainingDataset setVersion(int version) {
+    this.version = version;
+    return this;
+  }
+  
+}

--- a/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadTrainingDatasetLatestVersion.java
+++ b/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadTrainingDatasetLatestVersion.java
@@ -1,0 +1,70 @@
+package io.hops.util.featurestore.ops.read_ops;
+
+import io.hops.util.Hops;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.featurestore.FeaturegroupsAndTrainingDatasetsDTO;
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+import io.hops.util.featurestore.trainingdataset.TrainingDatasetDTO;
+
+import javax.xml.bind.JAXBException;
+import java.util.List;
+
+/**
+ * Builder class for Read-LatestTrainingDatasetVersion operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreReadTrainingDatasetLatestVersion extends FeaturestoreOp {
+  
+  /**
+   * Constructor
+   *
+   * @param name name of the training dataset
+   */
+  public FeaturestoreReadTrainingDatasetLatestVersion(String name) {
+    super(name);
+  }
+  
+  /**
+   * Gets the latest version of a training dataset in the featurestore
+   *
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   * @throws JAXBException JAXBException
+   * @return the latest version of the training dataset
+   */
+  public Integer read() throws FeaturestoreNotFound, JAXBException {
+    try {
+      return doGetLatestTrainingDatasetVersion(name, Hops.getFeaturestoreMetadata()
+        .setFeaturestore(featurestore).read());
+    } catch (Exception e) {
+      Hops.updateFeaturestoreMetadataCache().setFeaturestore(featurestore).write();
+      return doGetLatestTrainingDatasetVersion(name,
+        Hops.getFeaturestoreMetadata().setFeaturestore(featurestore).read());
+    }
+  }
+  
+  /**
+   * Method call to execute write operation
+   */
+  public void write(){
+    throw new UnsupportedOperationException("write() is not supported on a read operation");
+  }
+  
+  public FeaturestoreReadTrainingDatasetLatestVersion setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+    return this;
+  }
+  
+  /**
+   * Gets the latest version of a training dataset in the feature store, returns 0 if no version exists
+   *
+   * @param trainingDatasetName the name of the trainingDataset to get the latest version of
+   * @param featurestoreMetadata metadata of the featurestore to query
+   * @return the latest version of the training dataset
+   */
+  private static int doGetLatestTrainingDatasetVersion(
+    String trainingDatasetName, FeaturegroupsAndTrainingDatasetsDTO featurestoreMetadata) {
+    List<TrainingDatasetDTO> trainingDatasetDTOS = featurestoreMetadata.getTrainingDatasets();
+    return FeaturestoreHelper.getLatestTrainingDatasetVersion(trainingDatasetDTOS, trainingDatasetName);
+  }
+  
+}

--- a/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadTrainingDatasetPath.java
+++ b/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadTrainingDatasetPath.java
@@ -1,0 +1,85 @@
+package io.hops.util.featurestore.ops.read_ops;
+
+import io.hops.util.Constants;
+import io.hops.util.Hops;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.exceptions.TrainingDatasetDoesNotExistError;
+import io.hops.util.featurestore.FeaturegroupsAndTrainingDatasetsDTO;
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+import io.hops.util.featurestore.trainingdataset.TrainingDatasetDTO;
+
+import javax.xml.bind.JAXBException;
+import java.util.List;
+
+/**
+ * Builder class for Read-TrainingDatasetPath operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreReadTrainingDatasetPath extends FeaturestoreOp {
+  
+  /**
+   * Constructor
+   *
+   * @param name the name of the training dataset
+   */
+  public FeaturestoreReadTrainingDatasetPath(String name) {
+    super(name);
+  }
+  
+  /**
+   * Gets the training dataset HDFS path
+   *
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   * @throws JAXBException JAXBException
+   * @return the HDFS path to the training dataset
+   */
+  public String read()
+    throws FeaturestoreNotFound, JAXBException, TrainingDatasetDoesNotExistError {
+    try {
+      return doGetTrainingDatasetPath(name, version,
+        Hops.getFeaturestoreMetadata().setFeaturestore(featurestore).read());
+    } catch (Exception e) {
+      Hops.updateFeaturestoreMetadataCache().setFeaturestore(featurestore).write();
+      return doGetTrainingDatasetPath(name, version,
+        Hops.getFeaturestoreMetadata().setFeaturestore(featurestore).read());
+    }
+  }
+  
+  /**
+   * Method call to execute write operation
+   */
+  public void write(){
+    throw new UnsupportedOperationException("write() is not supported on a read operation");
+  }
+  
+  public FeaturestoreReadTrainingDatasetPath setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+    return this;
+  }
+  
+  public FeaturestoreReadTrainingDatasetPath setVersion(int version) {
+    this.version = version;
+    return this;
+  }
+  
+  /**
+   * Gets the HDFS path to a training dataset with a specific name and version in a featurestore
+   *
+   * @param trainingDataset        name of the training dataset
+   * @param featurestoreMetadata   featurestore metadata
+   * @param trainingDatasetVersion version of the training dataset
+   * @return the hdfs path to the training dataset
+   * @throws TrainingDatasetDoesNotExistError TrainingDatasetDoesNotExistError
+   */
+  private static String doGetTrainingDatasetPath(String trainingDataset,
+    int trainingDatasetVersion,
+    FeaturegroupsAndTrainingDatasetsDTO featurestoreMetadata) throws
+    TrainingDatasetDoesNotExistError {
+    List<TrainingDatasetDTO> trainingDatasetDTOList = featurestoreMetadata.getTrainingDatasets();
+    TrainingDatasetDTO trainingDatasetDTO = FeaturestoreHelper.findTrainingDataset(trainingDatasetDTOList,
+      trainingDataset, trainingDatasetVersion);
+    return Constants.HDFS_DEFAULT + trainingDatasetDTO.getHdfsStorePath() +
+      Constants.SLASH_DELIMITER + trainingDatasetDTO.getName();
+  }
+  
+}

--- a/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadTrainingDatasets.java
+++ b/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreReadTrainingDatasets.java
@@ -1,0 +1,49 @@
+package io.hops.util.featurestore.ops.read_ops;
+
+import io.hops.util.Hops;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+
+import javax.xml.bind.JAXBException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Builder class for Read-Training Datasets operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreReadTrainingDatasets extends FeaturestoreOp {
+  
+  /**
+   * Constructor
+   */
+  public FeaturestoreReadTrainingDatasets() {
+    super("");
+  }
+  
+  /**
+   * Gets a list of all training datasets from a particular featurestore
+   *
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   * @throws JAXBException JAXBException
+   * @return a list of training datasets in the featurestore
+   */
+  public List<String> read() throws FeaturestoreNotFound, JAXBException {
+    return Hops.getFeaturestoreMetadata().setFeaturestore(featurestore).read().
+      getTrainingDatasets().stream()
+      .map(td -> FeaturestoreHelper.getTableName(td.getName(), td.getVersion())).collect(Collectors.toList());
+  }
+  
+  /**
+   * Method call to execute write operation
+   */
+  public void write(){
+    throw new UnsupportedOperationException("write() is not supported on a read operation");
+  }
+  
+  public FeaturestoreReadTrainingDatasets setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+    return this;
+  }
+  
+}

--- a/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreSQLQuery.java
+++ b/src/main/java/io/hops/util/featurestore/ops/read_ops/FeaturestoreSQLQuery.java
@@ -1,0 +1,48 @@
+package io.hops.util.featurestore.ops.read_ops;
+
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+/**
+ * Builder class for SQL query on feature store
+ */
+public class FeaturestoreSQLQuery extends FeaturestoreOp {
+  
+  /**
+   * Constructor
+   *
+   * @param name the sql query
+   */
+  public FeaturestoreSQLQuery(String name) {
+    super(name);
+  }
+  
+  /**
+   * Runs an SQL query against the Featurestore Hive Database
+   *
+   * @return a spark dataframe with the results
+   */
+  public Dataset<Row> read() {
+    return FeaturestoreHelper.queryFeaturestore(spark, name, featurestore);
+  }
+  
+  /**
+   * Method call to execute write operation
+   */
+  public void write(){
+    throw new UnsupportedOperationException("write() is not supported on a read operation");
+  }
+  
+  public FeaturestoreSQLQuery setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+    return this;
+  }
+  
+  public FeaturestoreSQLQuery setSpark(SparkSession spark) {
+    this.spark = spark;
+    return this;
+  }
+}

--- a/src/main/java/io/hops/util/featurestore/ops/write_ops/FeaturestoreCreateFeaturegroup.java
+++ b/src/main/java/io/hops/util/featurestore/ops/write_ops/FeaturestoreCreateFeaturegroup.java
@@ -1,0 +1,169 @@
+package io.hops.util.featurestore.ops.write_ops;
+
+import io.hops.util.FeaturestoreRestClient;
+import io.hops.util.Hops;
+import io.hops.util.exceptions.DataframeIsEmpty;
+import io.hops.util.exceptions.FeaturegroupCreationError;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.exceptions.InvalidPrimaryKeyForFeaturegroup;
+import io.hops.util.exceptions.JWTNotFoundException;
+import io.hops.util.exceptions.SparkDataTypeNotRecognizedError;
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.feature.FeatureDTO;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+import io.hops.util.featurestore.stats.StatisticsDTO;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+import javax.xml.bind.JAXBException;
+import java.util.List;
+
+/**
+ * Builder class for Create-Featuregroup operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreCreateFeaturegroup extends FeaturestoreOp {
+  
+  /**
+   * Constructor
+   *
+   * @param name name of the featuregroup to create
+   */
+  public FeaturestoreCreateFeaturegroup(String name) {
+    super(name);
+  }
+  
+  /**
+   * Method call to execute read operation
+   */
+  public Object read() {
+    throw new UnsupportedOperationException("read() is not supported on a write operation");
+  }
+
+  /**
+   * Creates a new feature group in the featurestore
+   *
+   * @throws DataframeIsEmpty DataframeIsEmpty
+   * @throws SparkDataTypeNotRecognizedError SparkDataTypeNotRecognizedError
+   * @throws JAXBException JAXBException
+   * @throws InvalidPrimaryKeyForFeaturegroup InvalidPrimaryKeyForFeaturegroup
+   * @throws FeaturegroupCreationError FeaturegroupCreationError
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   * @throws JWTNotFoundException JWTNotFoundException
+   */
+  public void write()
+    throws DataframeIsEmpty, SparkDataTypeNotRecognizedError,
+    JAXBException, InvalidPrimaryKeyForFeaturegroup, FeaturegroupCreationError, FeaturestoreNotFound,
+    JWTNotFoundException {
+    if(dataframe == null) {
+      throw new IllegalArgumentException("Dataframe to create featuregroup from cannot be null, specify dataframe " +
+        "with " +
+        ".setDataframe(df)");
+    }
+    primaryKey = FeaturestoreHelper.primaryKeyGetOrDefault(primaryKey, dataframe);
+    FeaturestoreHelper.validatePrimaryKey(dataframe, primaryKey);
+    FeaturestoreHelper.validateMetadata(name, dataframe.dtypes(), dependencies, description);
+    StatisticsDTO statisticsDTO = FeaturestoreHelper.computeDataFrameStats(name, spark, dataframe,
+      featurestore, version, descriptiveStats, featureCorr, featureHistograms, clusterAnalysis, statColumns,
+      numBins, numClusters, corrMethod);
+    List<FeatureDTO> featuresSchema = FeaturestoreHelper.parseSparkFeaturesSchema(dataframe.schema(), primaryKey);
+    FeaturestoreRestClient.createFeaturegroupRest(featurestore, name, version, description, jobName, dependencies,
+      featuresSchema, statisticsDTO);
+    FeaturestoreHelper.insertIntoFeaturegroup(dataframe, spark, name,
+      featurestore, version);
+    //Update metadata cache since we created a new feature group
+    Hops.updateFeaturestoreMetadataCache().setFeaturestore(featurestore).write();
+    
+  }
+  
+  public FeaturestoreCreateFeaturegroup setName(String name) {
+    this.name = name;
+    return this;
+  }
+  
+  public FeaturestoreCreateFeaturegroup setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+    return this;
+  }
+  
+  public FeaturestoreCreateFeaturegroup setSpark(SparkSession spark) {
+    this.spark = spark;
+    return this;
+  }
+  
+  public FeaturestoreCreateFeaturegroup setVersion(int version) {
+    this.version = version;
+    return this;
+  }
+  
+  public FeaturestoreCreateFeaturegroup setCorrMethod(String corrMethod) {
+    this.corrMethod = corrMethod;
+    return this;
+  }
+  
+  public FeaturestoreCreateFeaturegroup setNumBins(int numBins) {
+    this.numBins = numBins;
+    return this;
+  }
+  
+  public FeaturestoreCreateFeaturegroup setNumClusters(int numClusters) {
+    this.numClusters = numClusters;
+    return this;
+  }
+  
+  public FeaturestoreCreateFeaturegroup setMode(String mode) {
+    this.mode = mode;
+    return this;
+  }
+  
+  public FeaturestoreCreateFeaturegroup setDataframe(Dataset<Row> dataframe) {
+    this.dataframe = dataframe;
+    return this;
+  }
+  
+  public FeaturestoreCreateFeaturegroup setDescriptiveStats(Boolean descriptiveStats) {
+    this.descriptiveStats = descriptiveStats;
+    return this;
+  }
+  
+  public FeaturestoreCreateFeaturegroup setFeatureCorr(Boolean featureCorr) {
+    this.featureCorr = featureCorr;
+    return this;
+  }
+  
+  public FeaturestoreCreateFeaturegroup setFeatureHistograms(Boolean featureHistograms) {
+    this.featureHistograms = featureHistograms;
+    return this;
+  }
+  
+  public FeaturestoreCreateFeaturegroup setClusterAnalysis(Boolean clusterAnalysis) {
+    this.clusterAnalysis = clusterAnalysis;
+    return this;
+  }
+  
+  public FeaturestoreCreateFeaturegroup setStatColumns(List<String> statColumns) {
+    this.statColumns = statColumns;
+    return this;
+  }
+  
+  public FeaturestoreCreateFeaturegroup setJobName(String jobName) {
+    this.jobName = jobName;
+    return this;
+  }
+  
+  public FeaturestoreCreateFeaturegroup setPrimaryKey(String primaryKey) {
+    this.primaryKey = primaryKey;
+    return this;
+  }
+  
+  public FeaturestoreCreateFeaturegroup setDescription(String description) {
+    this.description = description;
+    return this;
+  }
+  
+  public FeaturestoreCreateFeaturegroup setDependencies(List<String> dependencies) {
+    this.dependencies = dependencies;
+    return this;
+  }
+  
+}

--- a/src/main/java/io/hops/util/featurestore/ops/write_ops/FeaturestoreCreateTrainingDataset.java
+++ b/src/main/java/io/hops/util/featurestore/ops/write_ops/FeaturestoreCreateTrainingDataset.java
@@ -1,0 +1,195 @@
+package io.hops.util.featurestore.ops.write_ops;
+
+import io.hops.util.Constants;
+import io.hops.util.FeaturestoreRestClient;
+import io.hops.util.Hops;
+import io.hops.util.exceptions.CannotWriteImageDataFrameException;
+import io.hops.util.exceptions.DataframeIsEmpty;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.exceptions.JWTNotFoundException;
+import io.hops.util.exceptions.SparkDataTypeNotRecognizedError;
+import io.hops.util.exceptions.TrainingDatasetCreationError;
+import io.hops.util.exceptions.TrainingDatasetFormatNotSupportedError;
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.feature.FeatureDTO;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+import io.hops.util.featurestore.stats.StatisticsDTO;
+import io.hops.util.featurestore.trainingdataset.TrainingDatasetDTO;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.json.JSONObject;
+
+import javax.ws.rs.core.Response;
+import javax.xml.bind.JAXBException;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Builder class for Create-TrainingDataset operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreCreateTrainingDataset extends FeaturestoreOp {
+  
+  private static final Logger LOG = Logger.getLogger(FeaturestoreCreateTrainingDataset.class.getName());
+  
+  /**
+   * Constructor
+   *
+   * @param name name of the training dataset to create
+   */
+  public FeaturestoreCreateTrainingDataset(String name) {
+    super(name);
+  }
+  
+  /**
+   * Method call to execute read operation
+   */
+  public Object read() {
+    throw new UnsupportedOperationException("read() is not supported on a write operation");
+  }
+  
+
+  /**
+   * Creates a new training dataset in the featurestore
+   *
+   * @throws JWTNotFoundException JWTNotFoundException
+   * @throws DataframeIsEmpty DataframeIsEmpty
+   * @throws SparkDataTypeNotRecognizedError SparkDataTypeNotRecognizedError
+   * @throws JAXBException JAXBException
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   * @throws TrainingDatasetCreationError TrainingDatasetCreationError
+   * @throws TrainingDatasetFormatNotSupportedError TrainingDatasetFormatNotSupportedError
+   * @throws CannotWriteImageDataFrameException CannotWriteImageDataFrameException
+   */
+  public void write()
+    throws DataframeIsEmpty, SparkDataTypeNotRecognizedError,
+    JAXBException, FeaturestoreNotFound,
+    TrainingDatasetCreationError, TrainingDatasetFormatNotSupportedError, CannotWriteImageDataFrameException,
+    JWTNotFoundException {
+    if(dataframe == null) {
+      throw new IllegalArgumentException("Dataframe to create featuregroup from cannot be null, specify dataframe " +
+        "with " +
+        ".setDataframe(df)");
+    }
+    StatisticsDTO statisticsDTO = FeaturestoreHelper.computeDataFrameStats(name, spark,
+      dataframe, featurestore, version, descriptiveStats, featureCorr, featureHistograms,
+      clusterAnalysis, statColumns, numBins, numClusters, corrMethod);
+    List<FeatureDTO> featuresSchema = FeaturestoreHelper.parseSparkFeaturesSchema(dataframe.schema(), null);
+    Response response = FeaturestoreRestClient.createTrainingDatasetRest(featurestore, name, version, description,
+      jobName, dataFormat, dependencies, featuresSchema, statisticsDTO);
+    String jsonStrResponse = response.readEntity(String.class);
+    JSONObject jsonObjResponse = new JSONObject(jsonStrResponse);
+    TrainingDatasetDTO trainingDatasetDTO = FeaturestoreHelper.parseTrainingDatasetJson(jsonObjResponse);
+    String hdfsPath = trainingDatasetDTO.getHdfsStorePath() + Constants.SLASH_DELIMITER + name;
+    FeaturestoreHelper.writeTrainingDatasetHdfs(spark, dataframe, hdfsPath, dataFormat, Constants.SPARK_OVERWRITE_MODE);
+    if (dataFormat == Constants.TRAINING_DATASET_TFRECORDS_FORMAT) {
+      try {
+        JSONObject tfRecordSchemaJson = FeaturestoreHelper.getDataframeTfRecordSchemaJson(dataframe);
+        FeaturestoreHelper.writeTfRecordSchemaJson(trainingDatasetDTO.getHdfsStorePath()
+            + Constants.SLASH_DELIMITER + Constants.TRAINING_DATASET_TF_RECORD_SCHEMA_FILE_NAME,
+          tfRecordSchemaJson.toString());
+      } catch (Exception e) {
+        LOG.log(Level.SEVERE, "Could not save tf record schema json to HDFS for training dataset: " + name, e);
+      }
+    }
+    //Update metadata cache since we created a new training dataset
+    Hops.updateFeaturestoreMetadataCache().setFeaturestore(featurestore).write();
+  }
+  
+  public FeaturestoreCreateTrainingDataset setName(String name) {
+    this.name = name;
+    return this;
+  }
+  
+  public FeaturestoreCreateTrainingDataset setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+    return this;
+  }
+  
+  public FeaturestoreCreateTrainingDataset setSpark(SparkSession spark) {
+    this.spark = spark;
+    return this;
+  }
+  
+  public FeaturestoreCreateTrainingDataset setVersion(int version) {
+    this.version = version;
+    return this;
+  }
+  
+  public FeaturestoreCreateTrainingDataset setCorrMethod(String corrMethod) {
+    this.corrMethod = corrMethod;
+    return this;
+  }
+  
+  public FeaturestoreCreateTrainingDataset setNumBins(int numBins) {
+    this.numBins = numBins;
+    return this;
+  }
+  
+  public FeaturestoreCreateTrainingDataset setNumClusters(int numClusters) {
+    this.numClusters = numClusters;
+    return this;
+  }
+  
+  public FeaturestoreCreateTrainingDataset setMode(String mode) {
+    this.mode = mode;
+    return this;
+  }
+  
+  public FeaturestoreCreateTrainingDataset setDataframe(Dataset<Row> dataframe) {
+    this.dataframe = dataframe;
+    return this;
+  }
+  
+  public FeaturestoreCreateTrainingDataset setDescriptiveStats(Boolean descriptiveStats) {
+    this.descriptiveStats = descriptiveStats;
+    return this;
+  }
+  
+  public FeaturestoreCreateTrainingDataset setFeatureCorr(Boolean featureCorr) {
+    this.featureCorr = featureCorr;
+    return this;
+  }
+  
+  public FeaturestoreCreateTrainingDataset setFeatureHistograms(Boolean featureHistograms) {
+    this.featureHistograms = featureHistograms;
+    return this;
+  }
+  
+  public FeaturestoreCreateTrainingDataset setClusterAnalysis(Boolean clusterAnalysis) {
+    this.clusterAnalysis = clusterAnalysis;
+    return this;
+  }
+  
+  public FeaturestoreCreateTrainingDataset setStatColumns(List<String> statColumns) {
+    this.statColumns = statColumns;
+    return this;
+  }
+  
+  public FeaturestoreCreateTrainingDataset setJobName(String jobName) {
+    this.jobName = jobName;
+    return this;
+  }
+  
+  public FeaturestoreCreateTrainingDataset setPrimaryKey(String primaryKey) {
+    this.primaryKey = primaryKey;
+    return this;
+  }
+  
+  public FeaturestoreCreateTrainingDataset setDescription(String description) {
+    this.description = description;
+    return this;
+  }
+  
+  public FeaturestoreCreateTrainingDataset setDependencies(List<String> dependencies) {
+    this.dependencies = dependencies;
+    return this;
+  }
+  
+  public FeaturestoreCreateTrainingDataset setDataFormat(String dataFormat) {
+    this.dataFormat = dataFormat;
+    return this;
+  }
+  
+}

--- a/src/main/java/io/hops/util/featurestore/ops/write_ops/FeaturestoreInsertIntoFeaturegroup.java
+++ b/src/main/java/io/hops/util/featurestore/ops/write_ops/FeaturestoreInsertIntoFeaturegroup.java
@@ -1,0 +1,150 @@
+package io.hops.util.featurestore.ops.write_ops;
+
+import io.hops.util.FeaturestoreRestClient;
+import io.hops.util.exceptions.DataframeIsEmpty;
+import io.hops.util.exceptions.FeaturegroupDeletionError;
+import io.hops.util.exceptions.FeaturegroupUpdateStatsError;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.exceptions.JWTNotFoundException;
+import io.hops.util.exceptions.SparkDataTypeNotRecognizedError;
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+import io.hops.util.featurestore.stats.StatisticsDTO;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+import javax.xml.bind.JAXBException;
+import java.util.List;
+
+/**
+ * Builder class for InsertInto-Featuregroup operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreInsertIntoFeaturegroup extends FeaturestoreOp {
+  
+  /**
+   * Constructor
+   *
+   * @param name name of the featuregroup to insert into
+   */
+  public FeaturestoreInsertIntoFeaturegroup(String name) {
+    super(name);
+  }
+  
+  /**
+   * Method call to execute read operation
+   */
+  public Object read() {
+    throw new UnsupportedOperationException("read() is not supported on a write operation");
+  }
+  
+  /**
+   * Inserts a dataframes with rows into a featuregroup
+   *
+   * @throws DataframeIsEmpty DataframeIsEmpty
+   * @throws SparkDataTypeNotRecognizedError SparkDataTypeNotRecognizedError
+   * @throws JAXBException JAXBException
+   * @throws FeaturegroupUpdateStatsError FeaturegroupUpdateStatsError
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   * @throws JWTNotFoundException JWTNotFoundException
+   * @throws FeaturegroupDeletionError FeaturegroupDeletionError
+   */
+  public void write()
+    throws DataframeIsEmpty, SparkDataTypeNotRecognizedError,
+    JAXBException, FeaturegroupUpdateStatsError, FeaturestoreNotFound, JWTNotFoundException,
+    FeaturegroupDeletionError {
+    if(dataframe == null){
+      throw new IllegalArgumentException("Dataframe to insert cannot be null, specify dataframe with " +
+        ".setDataframe(df)");
+    }
+    spark.sparkContext().setJobGroup(
+      "Inserting dataframe into featuregroup",
+      "Inserting into featuregroup:" + name + " in the featurestore:" +
+        featurestore, true);
+    if (mode==null || !mode.equalsIgnoreCase("append") && !mode.equalsIgnoreCase("overwrite"))
+      throw new IllegalArgumentException("The supplied write mode: " + mode +
+        " does not match any of the supported modes: overwrite, append");
+    if (mode.equalsIgnoreCase("overwrite")) {
+      FeaturestoreRestClient.deleteTableContentsRest(featurestore, name, version);
+    }
+    spark.sparkContext().setJobGroup("", "", true);
+    FeaturestoreHelper.insertIntoFeaturegroup(dataframe, spark, name,
+      featurestore, version);
+    StatisticsDTO statisticsDTO = FeaturestoreHelper.computeDataFrameStats(name, spark, dataframe,
+      featurestore, version,
+      descriptiveStats, featureCorr, featureHistograms, clusterAnalysis, statColumns, numBins, numClusters,
+      corrMethod);
+    FeaturestoreRestClient.updateFeaturegroupStatsRest(name, featurestore, version, statisticsDTO);
+  }
+  
+  public FeaturestoreInsertIntoFeaturegroup setName(String name) {
+    this.name = name;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoFeaturegroup setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoFeaturegroup setSpark(SparkSession spark) {
+    this.spark = spark;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoFeaturegroup setVersion(int version) {
+    this.version = version;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoFeaturegroup setCorrMethod(String corrMethod) {
+    this.corrMethod = corrMethod;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoFeaturegroup setNumBins(int numBins) {
+    this.numBins = numBins;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoFeaturegroup setNumClusters(int numClusters) {
+    this.numClusters = numClusters;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoFeaturegroup setMode(String mode) {
+    this.mode = mode;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoFeaturegroup setDataframe(Dataset<Row> dataframe) {
+    this.dataframe = dataframe;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoFeaturegroup setDescriptiveStats(Boolean descriptiveStats) {
+    this.descriptiveStats = descriptiveStats;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoFeaturegroup setFeatureCorr(Boolean featureCorr) {
+    this.featureCorr = featureCorr;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoFeaturegroup setFeatureHistograms(Boolean featureHistograms) {
+    this.featureHistograms = featureHistograms;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoFeaturegroup setClusterAnalysis(Boolean clusterAnalysis) {
+    this.clusterAnalysis = clusterAnalysis;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoFeaturegroup setStatColumns(List<String> statColumns) {
+    this.statColumns = statColumns;
+    return this;
+  }
+  
+}

--- a/src/main/java/io/hops/util/featurestore/ops/write_ops/FeaturestoreInsertIntoTrainingDataset.java
+++ b/src/main/java/io/hops/util/featurestore/ops/write_ops/FeaturestoreInsertIntoTrainingDataset.java
@@ -1,0 +1,242 @@
+package io.hops.util.featurestore.ops.write_ops;
+
+import io.hops.util.Constants;
+import io.hops.util.FeaturestoreRestClient;
+import io.hops.util.Hops;
+import io.hops.util.exceptions.CannotWriteImageDataFrameException;
+import io.hops.util.exceptions.DataframeIsEmpty;
+import io.hops.util.exceptions.FeaturegroupUpdateStatsError;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.exceptions.JWTNotFoundException;
+import io.hops.util.exceptions.SparkDataTypeNotRecognizedError;
+import io.hops.util.exceptions.TrainingDatasetDoesNotExistError;
+import io.hops.util.exceptions.TrainingDatasetFormatNotSupportedError;
+import io.hops.util.featurestore.FeaturegroupsAndTrainingDatasetsDTO;
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+import io.hops.util.featurestore.stats.StatisticsDTO;
+import io.hops.util.featurestore.trainingdataset.TrainingDatasetDTO;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.json.JSONObject;
+
+import javax.ws.rs.core.Response;
+import javax.xml.bind.JAXBException;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Builder class for InsertInto-TrainingDataset operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreInsertIntoTrainingDataset extends FeaturestoreOp {
+  
+  private static final Logger LOG = Logger.getLogger(FeaturestoreInsertIntoTrainingDataset.class.getName());
+  
+  /**
+   * Constructor
+   *
+   * @param name name of the training dataset to insert into
+   */
+  public FeaturestoreInsertIntoTrainingDataset(String name) {
+    super(name);
+  }
+  
+  /**
+   * Method call to execute read operation
+   */
+  public Object read() {
+    throw new UnsupportedOperationException("read() is not supported on a write operation");
+  }
+  
+
+  /**
+   * Inserts a dataframes with rows into a training dataset
+   *
+   * @throws DataframeIsEmpty DataframeIsEmpty
+   * @throws SparkDataTypeNotRecognizedError SparkDataTypeNotRecognizedError
+   * @throws JAXBException JAXBException
+   * @throws FeaturegroupUpdateStatsError FeaturegroupUpdateStatsError
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   * @throws TrainingDatasetDoesNotExistError TrainingDatasetDoesNotExistError
+   * @throws TrainingDatasetFormatNotSupportedError TrainingDatasetFormatNotSupportedError
+   * @throws CannotWriteImageDataFrameException CannotWriteImageDataFrameException
+   */
+  public void write()
+    throws DataframeIsEmpty, SparkDataTypeNotRecognizedError,
+    JAXBException, FeaturegroupUpdateStatsError, FeaturestoreNotFound, TrainingDatasetDoesNotExistError,
+    TrainingDatasetFormatNotSupportedError, CannotWriteImageDataFrameException, JWTNotFoundException {
+    if(dataframe == null){
+      throw new IllegalArgumentException("Dataframe to insert cannot be null, specify dataframe with " +
+        ".setDataframe(df)");
+    }
+    if (mode==null || !mode.equalsIgnoreCase("overwrite"))
+      throw new IllegalArgumentException("The supplied write mode: " + mode +
+        " does not match any of the supported modes: overwrite (training datasets are immutable)");
+    try {
+      doInsertIntoTrainingDataset(spark, dataframe, name, featurestore,
+        Hops.getFeaturestoreMetadata().setFeaturestore(featurestore).read(), version,
+        descriptiveStats, featureCorr,
+        featureHistograms, clusterAnalysis, statColumns, numBins, corrMethod, numClusters,
+        mode);
+    } catch (Exception e) {
+      Hops.updateFeaturestoreMetadataCache().setFeaturestore(featurestore).write();
+      doInsertIntoTrainingDataset(spark, dataframe, name, featurestore,
+        Hops.getFeaturestoreMetadata().setFeaturestore(featurestore).read(), version,
+        descriptiveStats, featureCorr,
+        featureHistograms, clusterAnalysis, statColumns, numBins, corrMethod, numClusters,
+        mode);
+    }
+  }
+  
+  /**
+   * Inserts a spark dataframe into an existing training dataset (append/overwrite)
+   *
+   * @param sparkDf                the spark dataframe to insert
+   * @param sparkSession           the spark session
+   * @param trainingDataset        the name of the training dataset to insert into
+   * @param featurestore           the name of the featurestore where the training dataset resides
+   * @param featurestoreMetadata   metadata of the featurestore to query
+   * @param trainingDatasetVersion the version of the training dataset
+   * @param descriptiveStats       a boolean flag whether to compute descriptive statistics of the new data
+   * @param featureCorr            a boolean flag whether to compute feature correlation analysis of the new data
+   * @param featureHistograms      a boolean flag whether to compute feature histograms of the new data
+   * @param clusterAnalysis        a boolean flag whether to compute cluster analysis of the new data
+   * @param statColumns            a list of columns to compute statistics for (defaults to all columns
+   *                               that are numeric)
+   * @param numBins                number of bins to use for computing histograms
+   * @param corrMethod             the method to compute feature correlation with (pearson or spearman)
+   * @param numClusters            number of clusters to use for cluster analysis
+   * @param writeMode              the spark write mode (append/overwrite)
+   * @throws JAXBException JAXBException
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   * @throws TrainingDatasetDoesNotExistError TrainingDatasetDoesNotExistError
+   * @throws DataframeIsEmpty DataframeIsEmpty
+   * @throws FeaturegroupUpdateStatsError FeaturegroupUpdateStatsError
+   * @throws TrainingDatasetFormatNotSupportedError TrainingDatasetFormatNotSupportedError
+   * @throws SparkDataTypeNotRecognizedError SparkDataTypeNotRecognizedError
+   * @throws JWTNotFoundException JWTNotFoundException
+   */
+  private static void doInsertIntoTrainingDataset(
+    SparkSession sparkSession, Dataset<Row> sparkDf, String trainingDataset,
+    String featurestore, FeaturegroupsAndTrainingDatasetsDTO featurestoreMetadata, int trainingDatasetVersion,
+    Boolean descriptiveStats, Boolean featureCorr,
+    Boolean featureHistograms, Boolean clusterAnalysis, List<String> statColumns, Integer numBins,
+    String corrMethod, Integer numClusters, String writeMode)
+    throws JAXBException, TrainingDatasetDoesNotExistError, DataframeIsEmpty, FeaturegroupUpdateStatsError,
+    TrainingDatasetFormatNotSupportedError, SparkDataTypeNotRecognizedError, FeaturestoreNotFound,
+    CannotWriteImageDataFrameException, JWTNotFoundException {
+    featurestore = FeaturestoreHelper.featurestoreGetOrDefault(featurestore);
+    sparkSession = FeaturestoreHelper.sparkGetOrDefault(sparkSession);
+    corrMethod = FeaturestoreHelper.correlationMethodGetOrDefault(corrMethod);
+    numBins = FeaturestoreHelper.numBinsGetOrDefault(numBins);
+    numClusters = FeaturestoreHelper.numClustersGetOrDefault(numClusters);
+    List<TrainingDatasetDTO> trainingDatasetDTOList = featurestoreMetadata.getTrainingDatasets();
+    FeaturestoreHelper.findTrainingDataset(trainingDatasetDTOList,
+      trainingDataset, trainingDatasetVersion);
+    StatisticsDTO statisticsDTO = FeaturestoreHelper.computeDataFrameStats(trainingDataset, sparkSession,
+      sparkDf,
+      featurestore, trainingDatasetVersion,
+      descriptiveStats, featureCorr, featureHistograms, clusterAnalysis, statColumns, numBins, numClusters,
+      corrMethod);
+    Response response = FeaturestoreRestClient.updateTrainingDatasetStatsRest(trainingDataset, featurestore,
+      trainingDatasetVersion,
+      statisticsDTO);
+    String jsonStrResponse = response.readEntity(String.class);
+    JSONObject jsonObjResponse = new JSONObject(jsonStrResponse);
+    TrainingDatasetDTO updatedTrainingDatasetDTO = FeaturestoreHelper.parseTrainingDatasetJson(jsonObjResponse);
+    String hdfsPath = updatedTrainingDatasetDTO.getHdfsStorePath() + "/" + trainingDataset;
+    FeaturestoreHelper.writeTrainingDatasetHdfs(sparkSession, sparkDf, hdfsPath,
+      updatedTrainingDatasetDTO.getDataFormat(), writeMode);
+    if (updatedTrainingDatasetDTO.getDataFormat() == Constants.TRAINING_DATASET_TFRECORDS_FORMAT) {
+      JSONObject tfRecordSchemaJson = null;
+      try{
+        tfRecordSchemaJson = FeaturestoreHelper.getDataframeTfRecordSchemaJson(sparkDf);
+      } catch (Exception e){
+        LOG.log(Level.WARNING, "Could not infer the TF-record schema for the training dataset");
+      }
+      if(tfRecordSchemaJson != null){
+        try {
+          FeaturestoreHelper.writeTfRecordSchemaJson(updatedTrainingDatasetDTO.getHdfsStorePath()
+              + Constants.SLASH_DELIMITER + Constants.TRAINING_DATASET_TF_RECORD_SCHEMA_FILE_NAME,
+            tfRecordSchemaJson.toString());
+        } catch (Exception e) {
+          LOG.log(Level.WARNING, "Could not save tf record schema json to HDFS for training dataset: "
+            + trainingDataset, e);
+        }
+      }
+    }
+  }
+  
+  public FeaturestoreInsertIntoTrainingDataset setName(String name) {
+    this.name = name;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoTrainingDataset setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoTrainingDataset setSpark(SparkSession spark) {
+    this.spark = spark;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoTrainingDataset setVersion(int version) {
+    this.version = version;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoTrainingDataset setCorrMethod(String corrMethod) {
+    this.corrMethod = corrMethod;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoTrainingDataset setNumBins(int numBins) {
+    this.numBins = numBins;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoTrainingDataset setNumClusters(int numClusters) {
+    this.numClusters = numClusters;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoTrainingDataset setMode(String mode) {
+    this.mode = mode;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoTrainingDataset setDataframe(Dataset<Row> dataframe) {
+    this.dataframe = dataframe;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoTrainingDataset setDescriptiveStats(Boolean descriptiveStats) {
+    this.descriptiveStats = descriptiveStats;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoTrainingDataset setFeatureCorr(Boolean featureCorr) {
+    this.featureCorr = featureCorr;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoTrainingDataset setFeatureHistograms(Boolean featureHistograms) {
+    this.featureHistograms = featureHistograms;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoTrainingDataset setClusterAnalysis(Boolean clusterAnalysis) {
+    this.clusterAnalysis = clusterAnalysis;
+    return this;
+  }
+  
+  public FeaturestoreInsertIntoTrainingDataset setStatColumns(List<String> statColumns) {
+    this.statColumns = statColumns;
+    return this;
+  }
+  
+}

--- a/src/main/java/io/hops/util/featurestore/ops/write_ops/FeaturestoreUpdateFeaturegroupStats.java
+++ b/src/main/java/io/hops/util/featurestore/ops/write_ops/FeaturestoreUpdateFeaturegroupStats.java
@@ -1,0 +1,128 @@
+package io.hops.util.featurestore.ops.write_ops;
+
+import io.hops.util.FeaturestoreRestClient;
+import io.hops.util.exceptions.DataframeIsEmpty;
+import io.hops.util.exceptions.FeaturegroupUpdateStatsError;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.exceptions.JWTNotFoundException;
+import io.hops.util.exceptions.SparkDataTypeNotRecognizedError;
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+import io.hops.util.featurestore.stats.StatisticsDTO;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+import javax.xml.bind.JAXBException;
+import java.util.List;
+
+/**
+ * Builder class for Update-Featuregroup-Stats operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreUpdateFeaturegroupStats extends FeaturestoreOp {
+  
+  /**
+   * Constructor
+   *
+   * @param name name of the featuregroup to update stats of
+   */
+  public FeaturestoreUpdateFeaturegroupStats(String name) {
+    super(name);
+  }
+  
+  /**
+   * Method call to execute read operation
+   */
+  public Object read() {
+    throw new UnsupportedOperationException("read() is not supported on a write operation");
+  }
+  
+  /**
+   * Updates the stats of a featuregroup
+   *
+   * @throws DataframeIsEmpty DataframeIsEmpty
+   * @throws SparkDataTypeNotRecognizedError SparkDataTypeNotRecognizedError
+   * @throws JAXBException JAXBException
+   * @throws FeaturegroupUpdateStatsError FeaturegroupUpdateStatsError
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   */
+  public void write()
+    throws DataframeIsEmpty, SparkDataTypeNotRecognizedError,
+    JAXBException, FeaturegroupUpdateStatsError, FeaturestoreNotFound, JWTNotFoundException {
+    StatisticsDTO statisticsDTO = FeaturestoreHelper.computeDataFrameStats(name, spark, dataframe,
+      featurestore, version, descriptiveStats, featureCorr, featureHistograms, clusterAnalysis,
+      statColumns, numBins, numClusters, corrMethod);
+    FeaturestoreRestClient.updateFeaturegroupStatsRest(name, featurestore, version, statisticsDTO);
+  }
+  
+  public FeaturestoreUpdateFeaturegroupStats setName(String name) {
+    this.name = name;
+    return this;
+  }
+  
+  public FeaturestoreUpdateFeaturegroupStats setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+    return this;
+  }
+  
+  public FeaturestoreUpdateFeaturegroupStats setSpark(SparkSession spark) {
+    this.spark = spark;
+    return this;
+  }
+  
+  public FeaturestoreUpdateFeaturegroupStats setVersion(int version) {
+    this.version = version;
+    return this;
+  }
+  
+  public FeaturestoreUpdateFeaturegroupStats setCorrMethod(String corrMethod) {
+    this.corrMethod = corrMethod;
+    return this;
+  }
+  
+  public FeaturestoreUpdateFeaturegroupStats setNumBins(int numBins) {
+    this.numBins = numBins;
+    return this;
+  }
+  
+  public FeaturestoreUpdateFeaturegroupStats setNumClusters(int numClusters) {
+    this.numClusters = numClusters;
+    return this;
+  }
+  
+  public FeaturestoreUpdateFeaturegroupStats setMode(String mode) {
+    this.mode = mode;
+    return this;
+  }
+  
+  public FeaturestoreUpdateFeaturegroupStats setDataframe(Dataset<Row> dataframe) {
+    this.dataframe = dataframe;
+    return this;
+  }
+  
+  public FeaturestoreUpdateFeaturegroupStats setDescriptiveStats(Boolean descriptiveStats) {
+    this.descriptiveStats = descriptiveStats;
+    return this;
+  }
+  
+  public FeaturestoreUpdateFeaturegroupStats setFeatureCorr(Boolean featureCorr) {
+    this.featureCorr = featureCorr;
+    return this;
+  }
+  
+  public FeaturestoreUpdateFeaturegroupStats setFeatureHistograms(Boolean featureHistograms) {
+    this.featureHistograms = featureHistograms;
+    return this;
+  }
+  
+  public FeaturestoreUpdateFeaturegroupStats setClusterAnalysis(Boolean clusterAnalysis) {
+    this.clusterAnalysis = clusterAnalysis;
+    return this;
+  }
+  
+  public FeaturestoreUpdateFeaturegroupStats setStatColumns(List<String> statColumns) {
+    this.statColumns = statColumns;
+    return this;
+  }
+  
+}

--- a/src/main/java/io/hops/util/featurestore/ops/write_ops/FeaturestoreUpdateMetadataCache.java
+++ b/src/main/java/io/hops/util/featurestore/ops/write_ops/FeaturestoreUpdateMetadataCache.java
@@ -1,0 +1,45 @@
+package io.hops.util.featurestore.ops.write_ops;
+
+import io.hops.util.FeaturestoreRestClient;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+
+import javax.xml.bind.JAXBException;
+
+/**
+ * Builder class for Update-MetadataCache operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreUpdateMetadataCache extends FeaturestoreOp {
+  
+  /**
+   * Constructor
+   */
+  public FeaturestoreUpdateMetadataCache() {
+    super("");
+  }
+  
+  /**
+   * Method call to execute read operation
+   */
+  public Object read() {
+    throw new UnsupportedOperationException("read() is not supported on a write operation");
+  }
+  
+  /**
+   * Updates the metadata cache for a specified featurestore
+   *
+   * @throws JAXBException JAXBException
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   */
+  public void write()
+    throws JAXBException, FeaturestoreNotFound {
+    featurestore = FeaturestoreHelper.featurestoreGetOrDefault(featurestore);
+    FeaturestoreHelper.setFeaturestoreMetadataCache(FeaturestoreRestClient.getFeaturestoreMetadataRest(featurestore));
+  }
+  
+  public FeaturestoreUpdateMetadataCache setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+    return this;
+  }
+}

--- a/src/main/java/io/hops/util/featurestore/ops/write_ops/FeaturestoreUpdateTrainingDatasetStats.java
+++ b/src/main/java/io/hops/util/featurestore/ops/write_ops/FeaturestoreUpdateTrainingDatasetStats.java
@@ -1,0 +1,139 @@
+package io.hops.util.featurestore.ops.write_ops;
+
+import io.hops.util.FeaturestoreRestClient;
+import io.hops.util.exceptions.DataframeIsEmpty;
+import io.hops.util.exceptions.FeaturegroupUpdateStatsError;
+import io.hops.util.exceptions.FeaturestoreNotFound;
+import io.hops.util.exceptions.JWTNotFoundException;
+import io.hops.util.exceptions.SparkDataTypeNotRecognizedError;
+import io.hops.util.exceptions.TrainingDatasetDoesNotExistError;
+import io.hops.util.exceptions.TrainingDatasetFormatNotSupportedError;
+import io.hops.util.featurestore.FeaturestoreHelper;
+import io.hops.util.featurestore.ops.FeaturestoreOp;
+import io.hops.util.featurestore.ops.read_ops.FeaturestoreReadTrainingDataset;
+import io.hops.util.featurestore.stats.StatisticsDTO;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+import javax.xml.bind.JAXBException;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Builder class for Update-TrainingDataset-Stats operation on the Hopsworks Featurestore
+ */
+public class FeaturestoreUpdateTrainingDatasetStats extends FeaturestoreOp {
+  
+  /**
+   * Constructor
+   *
+   * @param name name of the training dataset to update stats of
+   */
+  public FeaturestoreUpdateTrainingDatasetStats(String name) {
+    super(name);
+  }
+  
+  /**
+   * Method call to execute read operation
+   */
+  public Object read() {
+    throw new UnsupportedOperationException("read() is not supported on a write operation");
+  }
+  
+  /**
+   * Updates the stats of a training dataset
+   *
+   * @throws DataframeIsEmpty DataframeIsEmpty
+   * @throws SparkDataTypeNotRecognizedError SparkDataTypeNotRecognizedError
+   * @throws JAXBException JAXBException
+   * @throws FeaturegroupUpdateStatsError FeaturegroupUpdateStatsError
+   * @throws IOException IOException
+   * @throws FeaturestoreNotFound FeaturestoreNotFound
+   * @throws TrainingDatasetDoesNotExistError TrainingDatasetDoesNotExistError
+   * @throws TrainingDatasetFormatNotSupportedError TrainingDatasetFormatNotSupportedError
+   * @throws JWTNotFoundException JWTNotFoundException
+   */
+  public void write()
+    throws DataframeIsEmpty, SparkDataTypeNotRecognizedError,
+    JAXBException, FeaturegroupUpdateStatsError, IOException, FeaturestoreNotFound,
+    TrainingDatasetDoesNotExistError, TrainingDatasetFormatNotSupportedError, JWTNotFoundException {
+    Dataset<Row> sparkDf = new FeaturestoreReadTrainingDataset(name).setSpark(spark)
+      .setFeaturestore(featurestore).setVersion(version).read();
+    StatisticsDTO statisticsDTO = FeaturestoreHelper.computeDataFrameStats(name, spark, sparkDf,
+      featurestore, version, descriptiveStats, featureCorr, featureHistograms, clusterAnalysis,
+      statColumns, numBins, numClusters, corrMethod);
+    FeaturestoreRestClient.updateTrainingDatasetStatsRest(name, featurestore, version, statisticsDTO);
+  }
+  
+  public FeaturestoreUpdateTrainingDatasetStats setName(String name) {
+    this.name = name;
+    return this;
+  }
+  
+  public FeaturestoreUpdateTrainingDatasetStats setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+    return this;
+  }
+  
+  public FeaturestoreUpdateTrainingDatasetStats setSpark(SparkSession spark) {
+    this.spark = spark;
+    return this;
+  }
+  
+  public FeaturestoreUpdateTrainingDatasetStats setVersion(int version) {
+    this.version = version;
+    return this;
+  }
+  
+  public FeaturestoreUpdateTrainingDatasetStats setCorrMethod(String corrMethod) {
+    this.corrMethod = corrMethod;
+    return this;
+  }
+  
+  public FeaturestoreUpdateTrainingDatasetStats setNumBins(int numBins) {
+    this.numBins = numBins;
+    return this;
+  }
+  
+  public FeaturestoreUpdateTrainingDatasetStats setNumClusters(int numClusters) {
+    this.numClusters = numClusters;
+    return this;
+  }
+  
+  public FeaturestoreUpdateTrainingDatasetStats setMode(String mode) {
+    this.mode = mode;
+    return this;
+  }
+  
+  public FeaturestoreUpdateTrainingDatasetStats setDataframe(Dataset<Row> dataframe) {
+    this.dataframe = dataframe;
+    return this;
+  }
+  
+  public FeaturestoreUpdateTrainingDatasetStats setDescriptiveStats(Boolean descriptiveStats) {
+    this.descriptiveStats = descriptiveStats;
+    return this;
+  }
+  
+  public FeaturestoreUpdateTrainingDatasetStats setFeatureCorr(Boolean featureCorr) {
+    this.featureCorr = featureCorr;
+    return this;
+  }
+  
+  public FeaturestoreUpdateTrainingDatasetStats setFeatureHistograms(Boolean featureHistograms) {
+    this.featureHistograms = featureHistograms;
+    return this;
+  }
+  
+  public FeaturestoreUpdateTrainingDatasetStats setClusterAnalysis(Boolean clusterAnalysis) {
+    this.clusterAnalysis = clusterAnalysis;
+    return this;
+  }
+  
+  public FeaturestoreUpdateTrainingDatasetStats setStatColumns(List<String> statColumns) {
+    this.statColumns = statColumns;
+    return this;
+  }
+  
+}


### PR DESCRIPTION
- Make API java/scala friendly instead of pythonic

E.g the API for creating a feature group with default parameters before
this PR:

```
import io.hops.util.Hops
import scala.collection.JavaConversions._
import collection.JavaConverters._

val jobId = null
val dependencies = List[String]().asJava
val primaryKey = null
val descriptiveStats = false
val featureCorr = false
val featureHistograms = false
val clusterAnalysis = false
val statColumns = List[String]().asJava
val numBins = null
val corrMethod = null
val numClusters = null
val description = "a spanish version of teams_features"

Hops.createFeaturegroup(
    spark, teamsFeaturesDf2, "teams_features_spanish", Hops.getProjectFeaturestore,
    1, description, jobId,
    dependencies, primaryKey, descriptiveStats, featureCorr,
      featureHistograms, clusterAnalysis, statColumns, numBins,
      corrMethod, numClusters)
```

After this PR:

```
import io.hops.util.Hops
Hops.createFeaturegroup("teams_features_spanish").setDataframe(teamsFeaturesDf2).write()
```