### PR TITLE
[HOPSWORKS-1049] Remove misleading featurestoreNotFound log

### DIFF
--- a/src/main/java/io/hops/util/Hops.java
+++ b/src/main/java/io/hops/util/Hops.java
@@ -144,8 +144,8 @@ public class Hops {
         LOG.log(Level.SEVERE,
           "Could not fetch the feature store metadata for feature store: " + Hops.getProjectFeaturestore(), e);
       } catch (FeaturestoreNotFound e) {
-        LOG.log(Level.INFO,
-          "Could not fetch the feature store metadata for feature store: " + Hops.getProjectFeaturestore(), e);
+        LOG.log(Level.FINEST,
+          "Did not cache featurestore metadata as the project does not have the feature store service enabled");
       }
     }
   }


### PR DESCRIPTION
- When a project does not have the feature store service enabled
  it is not necessary to log exception when featurestoreNotFound
  is thrown when trying to cache featurestore metadata at the client.