### PR TITLE
[HOPSWORKS-1435][featurestore] Unify feature store entity max length validation in backend

### DIFF
--- a/src/main/java/io/hops/util/featurestore/FeaturestoreHelper.java
+++ b/src/main/java/io/hops/util/featurestore/FeaturestoreHelper.java
@@ -1462,17 +1462,20 @@ public class FeaturestoreHelper {
       throw new IllegalArgumentException("Cannot create a feature group from an empty spark dataframe");
     }
   
-    if (schema.stream().anyMatch(f -> !featurestoreRegex.matcher(f.getName()).matches())) {
-      throw new IllegalArgumentException("Illegal feature name, one or more of the provided feature names is invalid." +
-        " Feature names can only contain lower case characters, numbers and underscores and cannot be longer than " +
-        featurestoreMetadataCache.getSettings().getFeaturestoreEntityNameMaxLength() + " characters or empty.");
-    }
-
-    if (schema.stream().anyMatch(f -> !Strings.isNullOrEmpty(f.getDescription()) && f.getDescription().length() >
-      featurestoreMetadataCache.getSettings().getFeaturestoreEntityDescriptionMaxLength())) {
-      throw new IllegalArgumentException("Invalid feature description, one or more of the provided feature " +
-        "descriptions is too long. Feature descriptions cannot be longer than "
-        + featurestoreMetadataCache.getSettings().getFeaturestoreEntityDescriptionMaxLength() + " characters.");
+    for (FeatureDTO featureDTO : schema) {
+      if (!featurestoreRegex.matcher(featureDTO.getName()).matches()) {
+        throw new IllegalArgumentException("Illegal feature name, the provided feature name " + featureDTO.getName() +
+          " is invalid. Feature names can only contain lower case characters, numbers and underscores and cannot be " +
+          "longer than " + featurestoreMetadataCache.getSettings().getFeaturestoreEntityNameMaxLength()  + " characters"
+          + " or empty.");
+      }
+      if (!Strings.isNullOrEmpty(featureDTO.getDescription()) && featureDTO.getDescription().length() >
+        featurestoreMetadataCache.getSettings().getFeaturestoreEntityDescriptionMaxLength()) {
+        throw new IllegalArgumentException("Illegal feature description, the provided feature description of " +
+          featureDTO.getName() + " is too long with " + featureDTO.getDescription().length() + " characters. Feature " +
+          "descriptions cannot be longer than " +
+          featurestoreMetadataCache.getSettings().getFeaturestoreEntityDescriptionMaxLength() + " characters.");
+      }
     }
   }
 

--- a/src/main/java/io/hops/util/featurestore/FeaturestoreHelper.java
+++ b/src/main/java/io/hops/util/featurestore/FeaturestoreHelper.java
@@ -1439,35 +1439,40 @@ public class FeaturestoreHelper {
    * Validates metadata provided by the user when creating new feature groups and training datasets
    *
    * @param name the name of the feature group/training dataset
-   * @param dtypes the schema of the provided spark dataframe
+   * @param schema the schema of the provided spark dataframe in terms of featureDTOs
    * @param description the description about the feature group/training dataset
    */
-  public static void validateMetadata(String name, Tuple2<String, String>[] dtypes, String description,
-    FeaturestoreClientSettingsDTO featurestoreClientSettingsDTO) {
-    if (name.length() > 256 || !featurestoreRegex.matcher(name).matches()) {
-      throw new IllegalArgumentException("Name of feature group/training dataset cannot be empty, " +
-        "cannot contain upper case characters, cannot exceed 256 characters, cannot contain hyphens ('-') " +
-        "and must match the regular expression: " + featurestoreClientSettingsDTO.getFeaturestoreRegex() +
-        ", the provided name: " + name + " is not valid");
+  public static void validateMetadata(String name, List<FeatureDTO> schema, String description) {
+    if (!featurestoreRegex.matcher(name).matches()) {
+      throw new IllegalArgumentException("Illegal feature store entity name, the provided name " + name + " is " +
+        "invalid. Entity names can only contain lower case characters, numbers and underscores and cannot be longer " +
+        "than " + featurestoreMetadataCache.getSettings().getFeaturestoreEntityNameMaxLength() +
+        " characters or empty.");
     }
 
-    if (dtypes.length == 0) {
+    if (!Strings.isNullOrEmpty(description) &&
+      description.length() > featurestoreMetadataCache.getSettings().getFeaturestoreEntityDescriptionMaxLength()) {
+      throw new IllegalArgumentException("Illegal feature store entity description, the provided description for " +
+        "the entity " + name + " is too long with " + description.length() + " characters. Entity descriptions cannot" +
+        " be longer than " + featurestoreMetadataCache.getSettings().getFeaturestoreEntityDescriptionMaxLength() +
+        " characters.");
+    }
+  
+    if (schema.size() == 0) {
       throw new IllegalArgumentException("Cannot create a feature group from an empty spark dataframe");
     }
   
-    for (int i = 0; i < dtypes.length; i++) {
-      if (dtypes[i]._1.length() > 767 || !featurestoreRegex.matcher(dtypes[i]._1).matches()) {
-        throw new IllegalArgumentException("Name of feature column cannot be empty, cannot exceed 767 characters, " +
-          "cannot contains hyphens ('-'), and must match the regular expression: " +
-          featurestoreClientSettingsDTO.getFeaturestoreRegex() +
-          ", the provided feature name: " + dtypes[i]._1 + " is not valid");
-      }
+    if (schema.stream().anyMatch(f -> !featurestoreRegex.matcher(f.getName()).matches())) {
+      throw new IllegalArgumentException("Illegal feature name, one or more of the provided feature names is invalid." +
+        " Feature names can only contain lower case characters, numbers and underscores and cannot be longer than " +
+        featurestoreMetadataCache.getSettings().getFeaturestoreEntityNameMaxLength() + " characters or empty.");
     }
 
-    if (description.length() > 2000) {
-      throw new IllegalArgumentException("Feature group/Training dataset description should not exceed " +
-        "the maximum length of 2000 characters, " +
-        "the provided description has length:" + description.length());
+    if (schema.stream().anyMatch(f -> !Strings.isNullOrEmpty(f.getDescription()) && f.getDescription().length() >
+      featurestoreMetadataCache.getSettings().getFeaturestoreEntityDescriptionMaxLength())) {
+      throw new IllegalArgumentException("Invalid feature description, one or more of the provided feature " +
+        "descriptions is too long. Feature descriptions cannot be longer than "
+        + featurestoreMetadataCache.getSettings().getFeaturestoreEntityDescriptionMaxLength() + " characters.");
     }
   }
 

--- a/src/main/java/io/hops/util/featurestore/dtos/settings/FeaturestoreClientSettingsDTO.java
+++ b/src/main/java/io/hops/util/featurestore/dtos/settings/FeaturestoreClientSettingsDTO.java
@@ -29,6 +29,8 @@ public class FeaturestoreClientSettingsDTO {
   
   private int featurestoreStatisticsMaxCorrelations;
   private String featurestoreRegex;
+  private int featurestoreEntityNameMaxLength;
+  private int featurestoreEntityDescriptionMaxLength;
   private int storageConnectorNameMaxLength;
   private int storageConnectorDescriptionMaxLength;
   private int jdbcStorageConnectorConnectionstringMaxLength;
@@ -36,20 +38,8 @@ public class FeaturestoreClientSettingsDTO {
   private int s3StorageConnectorBucketMaxLength;
   private int s3StorageConnectorAccesskeyMaxLength;
   private int s3StorageConnectorSecretkeyMaxLength;
-  private int cachedFeaturegroupNameMaxLength;
-  private int cachedFeaturegroupDescriptionMaxLength;
-  private int cachedFeaturegroupFeatureNameMaxLength;
-  private int cachedFeaturegroupFeatureDescriptionMaxLength;
-  private int onDemandFeaturegroupNameMaxLength;
-  private int onDemandFeaturegroupDescriptionMaxLength;
-  private int onDemandFeaturegroupFeatureNameMaxLength;
-  private int onDemandFeaturegroupFeatureDescriptionMaxLength;
   private int onDemandFeaturegroupSqlQueryMaxLength;
   private List<String> trainingDatasetDataFormats;
-  private int externalTrainingDatasetNameMaxLength;
-  private int hopsfsTrainingDatasetNameMaxLength;
-  private int trainingDatasetFeatureNameMaxLength;
-  private int trainingDatasetFeatureDescriptionMaxLength;
   private String onDemandFeaturegroupType;
   private String cachedFeaturegroupType;
   private String jdbcConnectorType;
@@ -61,7 +51,6 @@ public class FeaturestoreClientSettingsDTO {
   private String externalTrainingDatasetType;
   private String hopsfsTrainingDatasetDtoType;
   private String externalTrainingDatasetDtoType;
-  private int trainingDatasetDescriptionMaxLength;
   private String s3ConnectorDtoType;
   private String jdbcConnectorDtoType;
   private String hopsfsConnectorDtoType;
@@ -99,6 +88,24 @@ public class FeaturestoreClientSettingsDTO {
   
   public void setFeaturestoreRegex(String featurestoreRegex) {
     this.featurestoreRegex = featurestoreRegex;
+  }
+  
+  @XmlElement
+  public int getFeaturestoreEntityNameMaxLength() {
+    return featurestoreEntityNameMaxLength;
+  }
+  
+  public void setFeaturestoreEntityNameMaxLength(int featurestoreEntityNameMaxLength) {
+    this.featurestoreEntityNameMaxLength = featurestoreEntityNameMaxLength;
+  }
+  
+  @XmlElement
+  public int getFeaturestoreEntityDescriptionMaxLength() {
+    return featurestoreEntityDescriptionMaxLength;
+  }
+  
+  public void setFeaturestoreEntityDescriptionMaxLength(int featurestoreEntityDescriptionMaxLength) {
+    this.featurestoreEntityDescriptionMaxLength = featurestoreEntityDescriptionMaxLength;
   }
   
   @XmlElement
@@ -165,78 +172,6 @@ public class FeaturestoreClientSettingsDTO {
   }
   
   @XmlElement
-  public int getCachedFeaturegroupNameMaxLength() {
-    return cachedFeaturegroupNameMaxLength;
-  }
-  
-  public void setCachedFeaturegroupNameMaxLength(int cachedFeaturegroupNameMaxLength) {
-    this.cachedFeaturegroupNameMaxLength = cachedFeaturegroupNameMaxLength;
-  }
-  
-  @XmlElement
-  public int getCachedFeaturegroupDescriptionMaxLength() {
-    return cachedFeaturegroupDescriptionMaxLength;
-  }
-  
-  public void setCachedFeaturegroupDescriptionMaxLength(int cachedFeaturegroupDescriptionMaxLength) {
-    this.cachedFeaturegroupDescriptionMaxLength = cachedFeaturegroupDescriptionMaxLength;
-  }
-  
-  @XmlElement
-  public int getCachedFeaturegroupFeatureNameMaxLength() {
-    return cachedFeaturegroupFeatureNameMaxLength;
-  }
-  
-  public void setCachedFeaturegroupFeatureNameMaxLength(int cachedFeaturegroupFeatureNameMaxLength) {
-    this.cachedFeaturegroupFeatureNameMaxLength = cachedFeaturegroupFeatureNameMaxLength;
-  }
-  
-  @XmlElement
-  public int getCachedFeaturegroupFeatureDescriptionMaxLength() {
-    return cachedFeaturegroupFeatureDescriptionMaxLength;
-  }
-  
-  public void setCachedFeaturegroupFeatureDescriptionMaxLength(int cachedFeaturegroupFeatureDescriptionMaxLength) {
-    this.cachedFeaturegroupFeatureDescriptionMaxLength = cachedFeaturegroupFeatureDescriptionMaxLength;
-  }
-  
-  @XmlElement
-  public int getOnDemandFeaturegroupNameMaxLength() {
-    return onDemandFeaturegroupNameMaxLength;
-  }
-  
-  public void setOnDemandFeaturegroupNameMaxLength(int onDemandFeaturegroupNameMaxLength) {
-    this.onDemandFeaturegroupNameMaxLength = onDemandFeaturegroupNameMaxLength;
-  }
-  
-  @XmlElement
-  public int getOnDemandFeaturegroupDescriptionMaxLength() {
-    return onDemandFeaturegroupDescriptionMaxLength;
-  }
-  
-  public void setOnDemandFeaturegroupDescriptionMaxLength(int onDemandFeaturegroupDescriptionMaxLength) {
-    this.onDemandFeaturegroupDescriptionMaxLength = onDemandFeaturegroupDescriptionMaxLength;
-  }
-  
-  @XmlElement
-  public int getOnDemandFeaturegroupFeatureNameMaxLength() {
-    return onDemandFeaturegroupFeatureNameMaxLength;
-  }
-  
-  public void setOnDemandFeaturegroupFeatureNameMaxLength(int onDemandFeaturegroupFeatureNameMaxLength) {
-    this.onDemandFeaturegroupFeatureNameMaxLength = onDemandFeaturegroupFeatureNameMaxLength;
-  }
-  
-  @XmlElement
-  public int getOnDemandFeaturegroupFeatureDescriptionMaxLength() {
-    return onDemandFeaturegroupFeatureDescriptionMaxLength;
-  }
-  
-  public void setOnDemandFeaturegroupFeatureDescriptionMaxLength(int onDemandFeaturegroupFeatureDescriptionMaxLength) {
-    this.onDemandFeaturegroupFeatureDescriptionMaxLength = onDemandFeaturegroupFeatureDescriptionMaxLength;
-  }
-  
-  @XmlElement
   public int getOnDemandFeaturegroupSqlQueryMaxLength() {
     return onDemandFeaturegroupSqlQueryMaxLength;
   }
@@ -252,42 +187,6 @@ public class FeaturestoreClientSettingsDTO {
   
   public void setTrainingDatasetDataFormats(List<String> trainingDatasetDataFormats) {
     this.trainingDatasetDataFormats = trainingDatasetDataFormats;
-  }
-  
-  @XmlElement
-  public int getExternalTrainingDatasetNameMaxLength() {
-    return externalTrainingDatasetNameMaxLength;
-  }
-  
-  public void setExternalTrainingDatasetNameMaxLength(int externalTrainingDatasetNameMaxLength) {
-    this.externalTrainingDatasetNameMaxLength = externalTrainingDatasetNameMaxLength;
-  }
-  
-  @XmlElement
-  public int getHopsfsTrainingDatasetNameMaxLength() {
-    return hopsfsTrainingDatasetNameMaxLength;
-  }
-  
-  public void setHopsfsTrainingDatasetNameMaxLength(int hopsfsTrainingDatasetNameMaxLength) {
-    this.hopsfsTrainingDatasetNameMaxLength = hopsfsTrainingDatasetNameMaxLength;
-  }
-  
-  @XmlElement
-  public int getTrainingDatasetFeatureNameMaxLength() {
-    return trainingDatasetFeatureNameMaxLength;
-  }
-  
-  public void setTrainingDatasetFeatureNameMaxLength(int trainingDatasetFeatureNameMaxLength) {
-    this.trainingDatasetFeatureNameMaxLength = trainingDatasetFeatureNameMaxLength;
-  }
-  
-  @XmlElement
-  public int getTrainingDatasetFeatureDescriptionMaxLength() {
-    return trainingDatasetFeatureDescriptionMaxLength;
-  }
-  
-  public void setTrainingDatasetFeatureDescriptionMaxLength(int trainingDatasetFeatureDescriptionMaxLength) {
-    this.trainingDatasetFeatureDescriptionMaxLength = trainingDatasetFeatureDescriptionMaxLength;
   }
   
   @XmlElement
@@ -387,15 +286,6 @@ public class FeaturestoreClientSettingsDTO {
   
   public void setExternalTrainingDatasetDtoType(String externalTrainingDatasetDtoType) {
     this.externalTrainingDatasetDtoType = externalTrainingDatasetDtoType;
-  }
-  
-  @XmlElement
-  public int getTrainingDatasetDescriptionMaxLength() {
-    return trainingDatasetDescriptionMaxLength;
-  }
-  
-  public void setTrainingDatasetDescriptionMaxLength(int trainingDatasetDescriptionMaxLength) {
-    this.trainingDatasetDescriptionMaxLength = trainingDatasetDescriptionMaxLength;
   }
   
   @XmlElement

--- a/src/main/java/io/hops/util/featurestore/ops/write_ops/FeaturestoreCreateFeaturegroup.java
+++ b/src/main/java/io/hops/util/featurestore/ops/write_ops/FeaturestoreCreateFeaturegroup.java
@@ -144,13 +144,13 @@ public class FeaturestoreCreateFeaturegroup extends FeaturestoreOp {
     }
     FeaturestoreMetadataDTO featurestoreMetadata = FeaturestoreHelper.getFeaturestoreMetadataCache();
     primaryKey = FeaturestoreHelper.primaryKeyGetOrDefault(primaryKey, dataframe);
+    List<FeatureDTO> featuresSchema = FeaturestoreHelper.parseSparkFeaturesSchema(dataframe.schema(), primaryKey,
+      partitionBy, online, onlineTypes);
     FeaturestoreHelper.validatePrimaryKey(dataframe, primaryKey);
-    FeaturestoreHelper.validateMetadata(name, dataframe.dtypes(), description, featurestoreMetadata.getSettings());
+    FeaturestoreHelper.validateMetadata(name, featuresSchema, description);
     StatisticsDTO statisticsDTO = FeaturestoreHelper.computeDataFrameStats(name, getSpark(), dataframe,
       featurestore, version, descriptiveStats, featureCorr, featureHistograms, clusterAnalysis, statColumns,
       numBins, numClusters, corrMethod);
-    List<FeatureDTO> featuresSchema = FeaturestoreHelper.parseSparkFeaturesSchema(dataframe.schema(), primaryKey,
-      partitionBy, online, onlineTypes);
     if(!hudi) {
       FeaturestoreRestClient.createFeaturegroupRest(groupInputParamsIntoDTO(featuresSchema, statisticsDTO),
         FeaturestoreHelper.getFeaturegroupDtoTypeStr(featurestoreMetadata.getSettings(), onDemand));

--- a/src/main/java/io/hops/util/featurestore/ops/write_ops/FeaturestoreCreateTrainingDataset.java
+++ b/src/main/java/io/hops/util/featurestore/ops/write_ops/FeaturestoreCreateTrainingDataset.java
@@ -95,12 +95,12 @@ public class FeaturestoreCreateTrainingDataset extends FeaturestoreOp {
         "with .setDataframe(df)");
     }
     FeaturestoreMetadataDTO featurestoreMetadata = FeaturestoreHelper.getFeaturestoreMetadataCache();
-    FeaturestoreHelper.validateMetadata(name, dataframe.dtypes(), description, featurestoreMetadata.getSettings());
+    List<FeatureDTO> featuresSchema = FeaturestoreHelper.parseSparkFeaturesSchema(dataframe.schema(), null,
+      null, false, null);
+    FeaturestoreHelper.validateMetadata(name, featuresSchema, description);
     StatisticsDTO statisticsDTO = FeaturestoreHelper.computeDataFrameStats(name, getSpark(),
       dataframe, featurestore, version, descriptiveStats, featureCorr, featureHistograms,
       clusterAnalysis, statColumns, numBins, numClusters, corrMethod);
-    List<FeatureDTO> featuresSchema = FeaturestoreHelper.parseSparkFeaturesSchema(dataframe.schema(), null,
-      null, false, null);
     FeaturestoreStorageConnectorDTO storageConnectorDTO;
     if(storageConnector != null && !storageConnector.isEmpty()){
       storageConnectorDTO =


### PR DESCRIPTION
Decided to keep the validation in the client, because otherwise we will do a lot of work of computing statistics first and then possibly fail because of a malformed name or description.

https://logicalclocks.atlassian.net/browse/HOPSWORKS-1435